### PR TITLE
Fix cooldown for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,7 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 3
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
The `github-actions` ecosystem supports `cooldown,` but only `default-days`. The semver-specific options aren't supported for it.