### PR TITLE
Setup version 4 of the prototype

### DIFF
--- a/app/assets/sass/core/_markdown.scss
+++ b/app/assets/sass/core/_markdown.scss
@@ -1,0 +1,148 @@
+.app-markdown {
+	@include nhsuk-font($size: false);
+
+  h1:not([class]) {
+    @extend %nhsuk-heading-l;
+    max-width: 40rem;
+  }
+
+  h2:not([class]) {
+    @extend %nhsuk-heading-m;
+    max-width: 40rem;
+  }
+
+  h3:not([class]) {
+    @extend %nhsuk-heading-s;
+    max-width: 40rem;
+  }
+
+  h4:not([class]) {
+    @extend %nhsuk-heading-xs;
+    max-width: 40rem;
+  }
+
+  h5:not([class]) {
+    @include nhsuk-font($size: 19, $weight: "bold");
+    @include nhsuk-responsive-margin(4, "bottom");
+    margin-top: 0;
+    color: $nhsuk-secondary-text-colour;
+  }
+
+  h6:not([class]) {
+    @include nhsuk-font($size: 16, $weight: "bold");
+    @include nhsuk-responsive-margin(4, "bottom");
+    margin-top: 0;
+    color: $nhsuk-secondary-text-colour;
+  }
+
+  > p:not([class]),
+  > dl,
+  > blockquote p {
+    @extend %nhsuk-body-m;
+    max-width: 40rem;
+  }
+
+  > blockquote {
+    @extend .nhsuk-inset-text;
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  figure {
+    margin: 0;
+    @include nhsuk-responsive-margin(6, "bottom");
+
+    > a {
+      display: block;
+      outline: 1px solid rgba($nhsuk-border-colour, 0.5);
+
+      &:hover {
+        outline-color: $nhsuk-link-hover-colour;
+      }
+
+      &:active {
+        outline-color: $nhsuk-link-active-colour;
+      }
+    }
+
+    a img {
+      outline: 0;
+    }
+  }
+
+  figcaption {
+    @include nhsuk-responsive-margin(4, "top");
+    @include nhsuk-font($size: 19);
+
+    h3 {
+      @extend %nhsuk-heading-s;
+    }
+
+    hr {
+      @extend %nhsuk-section-break--m;
+    }
+
+    &:not([class]) {
+      color: $nhsuk-secondary-text-colour;
+    }
+  }
+
+  abbr {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+
+  strong,
+  b,
+  dt:not([class]) {
+    @include nhsuk-typography-weight-bold;
+  }
+
+  dd + dt {
+    margin-top: nhsuk-spacing(4);
+  }
+
+  dd {
+    margin-left: 0;
+  }
+
+  dd + dd {
+    margin-top: nhsuk-spacing(2);
+  }
+
+  ul,
+  ol {
+    @extend %nhsuk-list;
+    max-width: 40rem;
+
+    & li ul {
+      list-style-type: circle;
+
+      & li ul {
+        list-style-type: disc;
+      }
+    }
+  }
+
+  ol {
+    @extend %nhsuk-list--number;
+  }
+
+  ul {
+    @extend %nhsuk-list--bullet;
+  }
+
+  a:not([class]) {
+    @include nhsuk-link-style-default;
+  }
+
+  mark {
+    background-color: nhsuk-colour("yellow");
+  }
+
+  hr {
+    @extend %nhsuk-section-break;
+    @extend %nhsuk-section-break--visible;
+    @extend %nhsuk-section-break--xl;
+  }
+}

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -1,5 +1,7 @@
 @import "nhsuk-frontend/dist/nhsuk";
 
+@import "core/markdown";
+
 .nhsuk-summary-list__row {
   border-bottom: 1px solid #d8dde0;
 }

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,59 +1,39 @@
-module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
+const fs = require('fs')
+const path = require('path')
+
+module.exports = function (env) {
+  /* eslint-disable-line func-names,no-unused-vars */
+  /**
+   * Instantiate object used to store the methods registered as a
+   * 'filter' (of the same name) within nunjucks. You can override
+   * gov.uk core filters by creating filter methods of the same name.
+   *
+   * @type {object}
+   */
   const filters = {}
 
-  filters.nhsDate = function (dateInput) {
-    // Handle empty input
-    if (!dateInput) {
-      return ''
-    }
+  const folderPaths = [
+    path.join(__dirname, 'filters')
+  ]
 
-    let day, month, year
+  try {
+    folderPaths.forEach((folderPath) => {
+      const files = fs.readdirSync(folderPath)
 
-    // Handle both array and object formats
-    if (Array.isArray(dateInput)) {
-      // Array format: [day, month, year]
-      if (dateInput.length !== 3) {
-        return ''
-      }
-      [day, month, year] = dateInput
-    } else if (typeof dateInput === 'object') {
-      // Object format: {day: x, month: y, year: z}
-      day = dateInput.day
-      month = dateInput.month
-      year = dateInput.year
-    } else {
-      return ''
-    }
+      files.forEach((file) => {
+        if (path.extname(file) === '.js') {
+          const module = require(path.join(folderPath, file))
 
-    // Handle empty values
-    if (!day || !month || !year) {
-      return ''
-    }
-
-    // Month names array (index 0 = January)
-    const monthNames = [
-      'January', 'February', 'March', 'April', 'May', 'June',
-      'July', 'August', 'September', 'October', 'November', 'December'
-    ]
-
-    // Convert strings to numbers and validate
-    const dayNum = parseInt(day, 10)
-    const monthNum = parseInt(month, 10)
-    const yearNum = parseInt(year, 10)
-
-    // Validate ranges
-    if (dayNum < 1 || dayNum > 31 || monthNum < 1 || monthNum > 12 || yearNum < 1000) {
-      return ''
-    }
-
-    const date = new Date(yearNum, monthNum - 1, dayNum)
-
-    if (date.getFullYear() !== yearNum || date.getMonth() !== monthNum - 1 || date.getDate() !== dayNum) {
-      return ''
-    }
-
-    // Format: "1 January 2020"
-    return `${dayNum} ${monthNames[monthNum - 1]} ${yearNum}`
+          Object.entries(module).forEach(([name, func]) => {
+            if (typeof func === 'function') {
+              filters[name] = func
+            }
+          })
+        }
+      })
+    })
+  } catch (err) {
+    console.warn('Error loading filters:', err)
   }
 
   return filters

--- a/app/filters/dates.js
+++ b/app/filters/dates.js
@@ -1,0 +1,263 @@
+const { DateTime } = require('luxon')
+
+const ALLOWED_VALUES_FOR_MONTHS = [
+  ['1', '01', 'jan', 'january'],
+  ['2', '02', 'feb', 'february'],
+  ['3', '03', 'mar', 'march'],
+  ['4', '04', 'apr', 'april'],
+  ['5', '05', 'may'],
+  ['6', '06', 'jun', 'june'],
+  ['7', '07', 'jul', 'july'],
+  ['8', '08', 'aug', 'august'],
+  ['9', '09', 'sep', 'september'],
+  ['10', 'oct', 'october'],
+  ['11', 'nov', 'november'],
+  ['12', 'dec', 'december']
+]
+
+/**
+ * Formats a timestamp into GOV.UK date format (e.g. "5 May 2024").
+ * @param {Date|string} timestamp - A JS Date object or a date string.
+ * @returns {string} The formatted date string.
+ */
+const nhsukDate = (timestamp) => {
+  const format = 'd MMMM yyyy'
+
+  let datetime = DateTime.fromJSDate(timestamp, { locale: 'en-GB' }).toFormat(format)
+
+  if (datetime === 'Invalid DateTime') {
+    datetime = DateTime.fromISO(timestamp, { locale: 'en-GB' }).toFormat(format)
+  }
+
+  return datetime
+}
+
+/**
+ * Formats a timestamp into a 12-hour GOV.UK-style time string (e.g. "3pm", "12am (midnight)").
+ * @param {Date|string} timestamp - A JS Date object or a date string.
+ * @returns {string} The formatted time string.
+ */
+const nhsukTime = (timestamp) => {
+  let datetime = DateTime.fromJSDate(timestamp, { locale: 'en-GB' })
+
+  if (datetime === 'Invalid DateTime') {
+    datetime = DateTime.fromISO(timestamp, { locale: 'en-GB' })
+  }
+
+  const hour = datetime.toFormat('h:mm').replace(':00', '')
+  const meridiem = datetime.toFormat('a').toLowerCase()
+
+  let time = `${hour}${meridiem}`
+
+  if (time === '12am') {
+    time = '12am (midnight)'
+  } else if (time === '12pm') {
+    time = '12pm (midday)'
+  }
+
+  return time
+}
+
+/**
+ * Combines GOV.UK-style formatted date and time into a single string.
+ * @param {Date|string} timestamp - A date/time string or object.
+ * @param {boolean|string} [format=false] - If 'on', outputs "time on date".
+ * @returns {string} A human-readable string combining date and time.
+ */
+const nhsukDateTime = (timestamp, format = false) => {
+  if (timestamp === 'today' || timestamp === 'now') {
+    timestamp = DateTime.now().toString()
+  }
+
+  const date = nhsukDate(timestamp)
+  const time = nhsukTime(timestamp)
+
+  return format === 'on' ? `${time} on ${date}` : `${date} at ${time}`
+}
+
+/**
+ * Parses user input into a numeric month value if it matches allowed formats.
+ * @param {string} input - Raw user input for a month (e.g. "Feb", "2", "02").
+ * @returns {string|undefined} The normalised numeric month as string or undefined.
+ */
+const parseMonth = (input) => {
+  if (input == null) return undefined
+  const trimmedLowerCaseInput = input.trim().toLowerCase()
+  return ALLOWED_VALUES_FOR_MONTHS.find((month) =>
+    month.find((allowedValue) => allowedValue === trimmedLowerCaseInput)
+  )?.[0]
+}
+
+/**
+ * Converts a date input object (e.g. from a form) into an ISO date string.
+ * @param {Object} object - Object containing date fields.
+ * @param {string} [namePrefix] - Optional prefix for date field names.
+ * @returns {string} ISO date string (e.g. "2024-05-20") or partial (e.g. "2024-05").
+ */
+const isoDateFromDateInput = (object, namePrefix) => {
+  let day, month, year
+
+  if (namePrefix) {
+    day = Number(object[`${namePrefix}-day`])
+    month = Number(parseMonth(object[`${namePrefix}-month`]))
+    year = Number(object[`${namePrefix}-year`])
+  } else {
+    day = Number(object?.day)
+    month = Number(parseMonth(object?.month))
+    year = Number(object?.year)
+  }
+
+  try {
+    if (!day) {
+      return DateTime.local(year, month).toFormat('yyyy-LL')
+    }
+
+    return DateTime.local(year, month, day).toISODate()
+  } catch (error) {
+    return error.message.split(':')[0]
+  }
+}
+
+const asUTCDate = (y, m, d) => new Date(Date.UTC(y, m - 1, d))
+
+const toISODateString = ({ year, month, day }) => {
+  if (!year || !month || !day) return ''
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+/**
+ * Checks whether a given value is a valid Date.
+ * @param {*} value - Any input value.
+ * @returns {boolean} True if the value can be parsed into a valid Date.
+ */
+const isValidDate = (value) => {
+  const date = new Date(value)
+  return date instanceof Date && !isNaN(date)
+}
+
+/**
+ * Extracts day, month and year parts from a timestamp.
+ * @param {Date|string} timestamp - The date to extract parts from.
+ * @returns {{day: number, month: number, year: number}|null}
+ */
+const getDateParts = (timestamp) => {
+  if (!isValidDate(timestamp)) {
+    return null
+  }
+
+  const date = new Date(timestamp)
+
+  return {
+    day: date.getDate(),
+    month: date.getMonth() + 1,
+    year: date.getFullYear()
+  }
+}
+
+/**
+ * Extracts the day from a timestamp.
+ * @param {Date|string} timestamp - The date to extract from.
+ * @returns {number|null} Day of the month, or null if invalid.
+ */
+const getDay = (timestamp) => {
+  if (!isValidDate(timestamp)) {
+    return null
+  }
+
+  return new Date(timestamp).getDate()
+}
+
+/**
+ * Extracts the month from a timestamp.
+ * @param {Date|string} timestamp - The date to extract from.
+ * @returns {number|null} Month (1–12), or null if invalid.
+ */
+const getMonth = (timestamp) => {
+  if (!isValidDate(timestamp)) {
+    return null
+  }
+
+  return new Date(timestamp).getMonth() + 1
+}
+
+/**
+ * Extracts the year from a timestamp.
+ * @param {Date|string} timestamp - The date to extract from.
+ * @returns {number|null} Year, or null if invalid.
+ */
+const getYear = (timestamp) => {
+  if (!isValidDate(timestamp)) {
+    return null
+  }
+
+  return new Date(timestamp).getFullYear()
+}
+
+/**
+ * Checks if the given date is today.
+ * @param {Date|string|number} input - A Date object or something convertible to a Date.
+ * @returns {boolean}
+ */
+const isToday = (input) => {
+  const date = new Date(input)
+  const today = new Date()
+
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  )
+}
+
+/**
+ * Checks if the given date is tomorrow.
+ * @param {Date|string|number} input - A Date object or something convertible to a Date.
+ * @returns {boolean}
+ */
+const isTomorrow = (input) => {
+  const date = new Date(input)
+  const tomorrow = new Date()
+
+  tomorrow.setDate(tomorrow.getDate() + 1)
+
+  return (
+    date.getFullYear() === tomorrow.getFullYear() &&
+    date.getMonth() === tomorrow.getMonth() &&
+    date.getDate() === tomorrow.getDate()
+  )
+}
+
+/**
+ * Checks if the given date is yesterday.
+ * @param {Date|string|number} input - A Date object or something convertible to a Date.
+ * @returns {boolean}
+ */
+const isYesterday = (input) => {
+  const date = new Date(input)
+  const yesterday = new Date()
+
+  yesterday.setDate(yesterday.getDate() - 1)
+
+  return (
+    date.getFullYear() === yesterday.getFullYear() &&
+    date.getMonth() === yesterday.getMonth() &&
+    date.getDate() === yesterday.getDate()
+  )
+}
+
+module.exports = {
+  nhsukDate,
+  nhsukDateTime,
+  nhsukTime,
+  isoDateFromDateInput,
+  toISODateString,
+  asUTCDate,
+  isValidDate,
+  getDateParts,
+  getDay,
+  getMonth,
+  getYear,
+  isToday,
+  isTomorrow,
+  isYesterday
+}

--- a/app/filters/markdown.js
+++ b/app/filters/markdown.js
@@ -1,0 +1,31 @@
+const marked = require('marked')
+const { gfmHeadingId } = require('marked-gfm-heading-id')
+
+// Configure marked once at module load time (instead of on every call)
+marked.use(gfmHeadingId())
+
+/* ------------------------------------------------------------------
+utility function to parse markdown as HTML
+example: {{ "## Title" | markdownToHtml }}
+outputs: "<h2>Title</h2>"
+------------------------------------------------------------------ */
+const markdownToHtml = (markdown) => {
+  if (!markdown) {
+    return null
+  }
+
+  const text = markdown.replace(/\\r/g, '\n').replace(/\\t/g, ' ')
+  const html = marked.parse(text)
+
+  // Add nhsuk-* classes
+  let nhsukHtml = html.replace(/<p>/g, '<p class="nhsuk-body">')
+  nhsukHtml = nhsukHtml.replace(/<ol>/g, '<ol class="nhsuk-list nhsuk-list--number">')
+  nhsukHtml = nhsukHtml.replace(/<ul>/g, '<ul class="nhsuk-list nhsuk-list--bullet">')
+  nhsukHtml = nhsukHtml.replace(/<h2/g, '<h2 class="nhsuk-heading-l"')
+  nhsukHtml = nhsukHtml.replace(/<h3/g, '<h3 class="nhsuk-heading-m"')
+  nhsukHtml = nhsukHtml.replace(/<h4/g, '<h4 class="nhsuk-heading-s"')
+
+  return nhsukHtml
+}
+
+module.exports = { markdownToHtml }

--- a/app/filters/markdown.js
+++ b/app/filters/markdown.js
@@ -23,9 +23,9 @@ const markdownToHtml = (markdown) => {
   let nhsukHtml = html.replace(/<p>/g, '<p class="nhsuk-body">')
   nhsukHtml = nhsukHtml.replace(/<ol>/g, '<ol class="nhsuk-list nhsuk-list--number">')
   nhsukHtml = nhsukHtml.replace(/<ul>/g, '<ul class="nhsuk-list nhsuk-list--bullet">')
-  nhsukHtml = nhsukHtml.replace(/<h2/g, '<h2 class="nhsuk-heading-l"')
-  nhsukHtml = nhsukHtml.replace(/<h3/g, '<h3 class="nhsuk-heading-m"')
-  nhsukHtml = nhsukHtml.replace(/<h4/g, '<h4 class="nhsuk-heading-s"')
+  nhsukHtml = nhsukHtml.replace(/<h2/g, '<h2 class="nhsuk-heading-m"')
+  nhsukHtml = nhsukHtml.replace(/<h3/g, '<h3 class="nhsuk-heading-s"')
+  nhsukHtml = nhsukHtml.replace(/<h4/g, '<h4 class="nhsuk-heading-xs"')
 
   return nhsukHtml
 }

--- a/app/filters/markdown.js
+++ b/app/filters/markdown.js
@@ -1,8 +1,10 @@
-const marked = require('marked')
-const { gfmHeadingId } = require('marked-gfm-heading-id')
+const MarkdownIt = require('markdown-it')
 
-// Configure marked once at module load time (instead of on every call)
-marked.use(gfmHeadingId())
+const markdownIt = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true
+})
 
 /* ------------------------------------------------------------------
 utility function to parse markdown as HTML
@@ -15,7 +17,7 @@ const markdownToHtml = (markdown) => {
   }
 
   const text = markdown.replace(/\\r/g, '\n').replace(/\\t/g, ' ')
-  const html = marked.parse(text)
+  const html = markdownIt.render(text)
 
   // Add nhsuk-* classes
   let nhsukHtml = html.replace(/<p>/g, '<p class="nhsuk-body">')

--- a/app/filters/telephone.js
+++ b/app/filters/telephone.js
@@ -1,0 +1,12 @@
+const telephoneLink = (telephone) => {
+  if (!telephone) {
+    return ''
+  }
+
+  const text = String(telephone)
+  const href = text.replace(/[^\d+]/g, '')
+
+  return `[${text}](tel:${href})`
+}
+
+module.exports = { telephoneLink }

--- a/app/locals.js
+++ b/app/locals.js
@@ -6,6 +6,7 @@ module.exports = (req, res, next) => {
   //
   // res.locals.organisationName = 'NHS'
 
+  res.locals.serviceUrl = 'digital-lung-cancer-screening.nhs.uk'
   res.locals.serviceEmail = 'england.digitallungcancerscreening@nhs.net'
   res.locals.serviceTelephone = '020 3835 1600'
 

--- a/app/locals.js
+++ b/app/locals.js
@@ -1,10 +1,12 @@
-module.exports = function (req, res, next) {
+module.exports = (req, res, next) => {
   // You can set any additional local variables here.
   // These will be made available to any views
   //
   // For example:
   //
-  // req.locals.organisationName = 'NHS'
+  // res.locals.organisationName = 'NHS'
+
+  res.locals.serviceEmail = 'england.digitallungcancerscreening@nhs.net'
 
   next()
 }

--- a/app/locals.js
+++ b/app/locals.js
@@ -7,6 +7,7 @@ module.exports = (req, res, next) => {
   // res.locals.organisationName = 'NHS'
 
   res.locals.serviceEmail = 'england.digitallungcancerscreening@nhs.net'
+  res.locals.serviceTelephone = '020 3835 1600'
 
   next()
 }

--- a/app/prototype_v4/content/accessibility.md
+++ b/app/prototype_v4/content/accessibility.md
@@ -47,7 +47,7 @@ We'll consider your request and get back to you in 7-14 days.
 
 The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](#).
 
-## Technical information about this website'2 accessibility
+## Technical information about this website's accessibility
 
 NHS England is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
@@ -73,8 +73,6 @@ The content listed below is non-accessible for the following reasons.
 
 ## What we're doing to improve accessibility
 
-##
-
 We have an alternate phone service that increases accessibility for all users. To access this service, please call [020 3835 1600](tel:02038351600).
 
 We have published tools and guidance on accessibility in the NHS digital service manual based on extensive testing. The service manual helps our teams build products and services to meet the same accessibility standards.
@@ -96,7 +94,7 @@ We are making sure that accessibility issues highlighted in this statement are b
 - prioritising accessibility remedial work in all new development and improvement projects
 - working with suppliers to improve the accessibility of their products
 
-## Preparation of this accessibilit2 statement
+## Preparation of this accessibility statement
 
 This statement was prepared on 19th March 2026.
 

--- a/app/prototype_v4/content/accessibility.md
+++ b/app/prototype_v4/content/accessibility.md
@@ -25,7 +25,7 @@ Due to the short-term nature of the test of the online service and the delivery 
 
 We have tested this website for accessibility issues with automated tools and through manual testing. We have a phone service for people who are unable to access this website.
 
-If you are unable to test the online service, please call us on [020 3835 1600](tel:02038351600)
+If you are unable to test the online service, please call us on {{ serviceTelephone | telephoneLink }}
 
 We know some parts of this website are not fully accessible:
 
@@ -73,7 +73,7 @@ The content listed below is non-accessible for the following reasons.
 
 ## What we're doing to improve accessibility
 
-We have an alternate phone service that increases accessibility for all users. To access this service, please call [020 3835 1600](tel:02038351600).
+We have an alternate phone service that increases accessibility for all users. To access this service, please call {{ serviceTelephone | telephoneLink }}.
 
 We have published tools and guidance on accessibility in the NHS digital service manual based on extensive testing. The service manual helps our teams build products and services to meet the same accessibility standards.
 

--- a/app/prototype_v4/content/accessibility.md
+++ b/app/prototype_v4/content/accessibility.md
@@ -1,0 +1,107 @@
+---
+title: Accessibility statement for NHS check if you need a lung scan
+---
+
+This statement was created in March 2026.
+
+This accessibility statement applies to the website [digital-lung-cancer-screening.nhs.uk](#)
+
+This website is run by NHS England. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
+- change colours, contrast levels and fonts using browser or device settings
+- zoom in up to 400% without the text spilling off the screen
+- navigate most of the website using a keyboard or speech recognition software
+- listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We've also made the website text as simple as possible to understand.
+
+[AbilityNet](#) has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We have used the NHS service standard and NHS design system to design and build this website which has been fully accessibility tested.
+
+Due to the short-term nature of the test of the online service and the delivery schedule we were unable to test the accessibility of this website with people with access needs.
+
+We have tested this website for accessibility issues with automated tools and through manual testing. We have a phone service for people who are unable to access this website.
+
+If you are unable to test the online service, please call us on [020 3835 1600](tel:02038351600)
+
+We know some parts of this website are not fully accessible:
+
+- There are some issues with accessibility of the content of our service, relating to error handling, text and headings and text fields and labelling
+
+Details of this can be found below in the 'Non-accessible content' section.
+
+## Feedback and contact information
+
+If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+
+If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille:
+
+- email [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+
+We'll consider your request and get back to you in 7-14 days.
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](#).
+
+## Technical information about this website'2 accessibility
+
+NHS England is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines (WCAG) version 2.2](#) AA standard, due to the non-compliances listed below.
+
+## Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Error handling
+
+- There is no error summary at the top of the page if there are errors
+
+#### Text and headings
+
+- Questions on pages are not marked as 'Heading level 2'
+
+#### Text fields and labelling
+
+- Text entry fields are editable but not announced as editable for screenreader users
+
+## What we're doing to improve accessibility
+
+##
+
+We have an alternate phone service that increases accessibility for all users. To access this service, please call [020 3835 1600](tel:02038351600).
+
+We have published tools and guidance on accessibility in the NHS digital service manual based on extensive testing. The service manual helps our teams build products and services to meet the same accessibility standards.
+
+At NHS England, creating an accessible service is a team effort. We want our teams to make accessible services by:
+
+- considering accessibility at the start of their project, and throughout
+- making accessibility the whole team's responsibility
+- researching with disabled users
+- using a library of accessible components and patterns
+- carrying out regular accessibility audits and testing
+- designing and building to level AA of WCAG 2.2 – which is NHS England policy
+
+As part of this commitment, we have set up a cross-functional accessibility working group to make sure that accessibility remains at the core of everything we do.
+
+We are making sure that accessibility issues highlighted in this statement are being prioritised and fixed. Measures include:
+
+- ongoing improvements to the NHS design system with a focus on accessibility
+- prioritising accessibility remedial work in all new development and improvement projects
+- working with suppliers to improve the accessibility of their products
+
+## Preparation of this accessibilit2 statement
+
+This statement was prepared on 19th March 2026.
+
+This website was last tested on 17th March 2026 against the WCAG 2.2 AA standard by the product team of NHS check if you need a lung scan.
+
+Content was selected to make sure a good representation of different pages, templates and components were tested as well as key content and user journeys.
+
+This website's accessibility will be reviewed on a regular basis and this accessibility statement updated with any relevant changes.

--- a/app/prototype_v4/content/accessibility.md
+++ b/app/prototype_v4/content/accessibility.md
@@ -1,5 +1,5 @@
 ---
-title: Accessibility statement for NHS check if you need a lung scan
+title: Accessibility statement for NHS {{ serviceName | lower }}
 ---
 
 This statement was created in March 2026.
@@ -98,7 +98,7 @@ We are making sure that accessibility issues highlighted in this statement are b
 
 This statement was prepared on 19th March 2026.
 
-This website was last tested on 17th March 2026 against the WCAG 2.2 AA standard by the product team of NHS check if you need a lung scan.
+This website was last tested on 17th March 2026 against the WCAG 2.2 AA standard by the product team of NHS {{ serviceName | lower }}.
 
 Content was selected to make sure a good representation of different pages, templates and components were tested as well as key content and user journeys.
 

--- a/app/prototype_v4/content/accessibility.md
+++ b/app/prototype_v4/content/accessibility.md
@@ -35,11 +35,11 @@ Details of this can be found below in the 'Non-accessible content' section.
 
 ## Feedback and contact information
 
-If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact: {{ serviceEmail }}
 
 If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille:
 
-- email [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+- email {{ serviceEmail }}
 
 We'll consider your request and get back to you in 7-14 days.
 

--- a/app/prototype_v4/content/accessibility.md
+++ b/app/prototype_v4/content/accessibility.md
@@ -4,7 +4,7 @@ title: Accessibility statement for NHS {{ serviceName | lower }}
 
 This statement was created in March 2026.
 
-This accessibility statement applies to the website [digital-lung-cancer-screening.nhs.uk](#)
+This accessibility statement applies to the website {{ serviceUrl }}
 
 This website is run by NHS England. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 

--- a/app/prototype_v4/content/contact.md
+++ b/app/prototype_v4/content/contact.md
@@ -12,4 +12,4 @@ Saturdays 8am to 1pm
 
 ## If you have questions about the online service
 
-Contact us by email: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+Contact us by email: {{ serviceEmail }}

--- a/app/prototype_v4/content/contact.md
+++ b/app/prototype_v4/content/contact.md
@@ -1,0 +1,15 @@
+---
+title: Contact us
+---
+
+## To complete your lung cancer screening by phone
+
+Call us on: [020 3835 1600](tel:02038351600)
+
+**Phone lines are open:**
+Monday to Friday 8am to 8pm
+Saturdays 8am to 1pm
+
+## If you have questions about the online service
+
+Contact us by email: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)

--- a/app/prototype_v4/content/contact.md
+++ b/app/prototype_v4/content/contact.md
@@ -4,7 +4,7 @@ title: Contact us
 
 ## To complete your lung cancer screening by phone
 
-Call us on: [020 3835 1600](tel:02038351600)
+Call us on: {{ serviceTelephone | telephoneLink }}
 
 **Phone lines are open:**
 Monday to Friday 8am to 8pm

--- a/app/prototype_v4/content/cookies.md
+++ b/app/prototype_v4/content/cookies.md
@@ -1,5 +1,5 @@
 ---
-title: NHS check if you need a lung scan cookies policy
+title: NHS {{ serviceName | lower }} cookies policy
 ---
 
 Version 1.0, 11 March 2026
@@ -8,19 +8,19 @@ Version 1.0, 11 March 2026
 
 This cookies policy relates to the service provided by NHS England.
 
-NHS England ("we" or "us") uses cookies to deliver the NHS check if you need a lung scan.
+NHS England ("we" or "us") uses cookies to deliver the NHS {{ serviceName | lower }}.
 
-The information set out in this policy is provided in addition to the [NHS check if you need a lung scan privacy policy](/prototype_v4/privacy-policy) and should be read alongside it.
+The information set out in this policy is provided in addition to the [NHS {{ serviceName | lower }} privacy policy](/prototype_v4/privacy-policy) and should be read alongside it.
 
 We put small files called cookies on your device (for example, your phone).
 
 Cookies are widely used to make websites and apps work, or work more efficiently, as well as to provide services and functionalities for users.
 
-We only put cookies on your device that are required for the NHS check if you need a lung scan to work ("strictly necessary cookies").
+We only put cookies on your device that are required for the NHS {{ serviceName | lower }} to work ("strictly necessary cookies").
 
-We ask you to accept our cookies policy when you accept the NHS check if you need a lung scan terms of use and privacy policy. In doing so, you agree to let us put the strictly necessary cookies on your device.
+We ask you to accept our cookies policy when you accept the NHS {{ serviceName | lower }} terms of use and privacy policy. In doing so, you agree to let us put the strictly necessary cookies on your device.
 
-The strictly necessary cookies we need to put on your device for the NHS check if you need a lung scan to work are listed here.
+The strictly necessary cookies we need to put on your device for the NHS {{ serviceName | lower }} to work are listed here.
 
 ## Essential cookies
 
@@ -32,7 +32,7 @@ The strictly necessary cookies we need to put on your device for the NHS check i
 
 ## Cookies set by Qualtrics
 
-The NHS check if you need a lung scan uses Qualtrics cookies for the purpose of capturing responses to feedback surveys.
+The NHS {{ serviceName | lower }} uses Qualtrics cookies for the purpose of capturing responses to feedback surveys.
 
 Details on how Qualtrics uses cookies can be found in the [Qualtrics cookies policy](#), which can be accessed from within the feedback survey.
 
@@ -44,11 +44,11 @@ You can select your cookie preferences so that you do not get any cookies (excep
 
 You can also delete the cookies already on your device, and you can set your browser or device to prevent them being placed.
 
-Please be aware that if you set your preferences to not allow cookies, it could limit the functionality of the NHS check if you need a lung scan as it needs the strictly necessary cookies to function.
+Please be aware that if you set your preferences to not allow cookies, it could limit the functionality of the NHS {{ serviceName | lower }} as it needs the strictly necessary cookies to function.
 
 ## Changes to this cookies policy
 
-The NHS check if you need a lung scan [terms of use](/prototype_v4/terms-of-use), [privacy policy](/prototype_v4/privacy-policy) and cookies policy may change. If you use the NHS check if you need a lung scan service again in the future you will be subject to the policies which exist at that time.
+The NHS {{ serviceName | lower }} [terms of use](/prototype_v4/terms-of-use), [privacy policy](/prototype_v4/privacy-policy) and cookies policy may change. If you use the NHS {{ serviceName | lower }} service again in the future you will be subject to the policies which exist at that time.
 
 ## Version history
 

--- a/app/prototype_v4/content/cookies.md
+++ b/app/prototype_v4/content/cookies.md
@@ -1,0 +1,55 @@
+---
+title: NHS check if you need a lung scan cookies policy
+---
+
+Version 1.0, 11 March 2026
+
+> First release of the service for pilot GP surgeries.
+
+This cookies policy relates to the service provided by NHS England.
+
+NHS England ("we" or "us") uses cookies to deliver the NHS check if you need a lung scan.
+
+The information set out in this policy is provided in addition to the [NHS check if you need a lung scan privacy policy](/prototype_v4/privacy-policy) and should be read alongside it.
+
+We put small files called cookies on your device (for example, your phone).
+
+Cookies are widely used to make websites and apps work, or work more efficiently, as well as to provide services and functionalities for users.
+
+We only put cookies on your device that are required for the NHS check if you need a lung scan to work ("strictly necessary cookies").
+
+We ask you to accept our cookies policy when you accept the NHS check if you need a lung scan terms of use and privacy policy. In doing so, you agree to let us put the strictly necessary cookies on your device.
+
+The strictly necessary cookies we need to put on your device for the NHS check if you need a lung scan to work are listed here.
+
+## Essential cookies
+
+| Name | Purpose | Expires |
+| --- | --- | --- |
+| sessionid | This cookie is used by Django to identify your session on the site. It allows the website to remember information as you navigate between pages. No personal data is stored in the cookie itself, it only contains a session identifier. | The end of the session. When you close the browser window, sign out or your session expires. |
+| ASLBSA and ASLBSACORS | These cookies are created by Azure and help identify different users even if they share the same IP address, allowing for a more even distribution of traffic among origins. | The end of the session. When you close the browser window, sign out or your session expires. |
+| csrftoken | This cookie is created by Django to protect the site from Cross-Site Request Forgery (CSRF) attacks. It ensures that form submissions and other actions come from you and not from a malicious third party. | Typically one year, unless your browser clears cookies. |
+
+## Cookies set by Qualtrics
+
+The NHS check if you need a lung scan uses Qualtrics cookies for the purpose of capturing responses to feedback surveys.
+
+Details on how Qualtrics uses cookies can be found in the [Qualtrics cookies policy](#), which can be accessed from within the feedback survey.
+
+## Your cookie choices
+
+The majority of devices and browsers will allow you to alter the settings used for cookies and disable and enable them as you require.
+
+You can select your cookie preferences so that you do not get any cookies (except strictly necessary cookies) if you prefer not to receive them.
+
+You can also delete the cookies already on your device, and you can set your browser or device to prevent them being placed.
+
+Please be aware that if you set your preferences to not allow cookies, it could limit the functionality of the NHS check if you need a lung scan as it needs the strictly necessary cookies to function.
+
+## Changes to this cookies policy
+
+The NHS check if you need a lung scan [terms of use](/prototype_v4/terms-of-use), [privacy policy](/prototype_v4/privacy-policy) and cookies policy may change. If you use the NHS check if you need a lung scan service again in the future you will be subject to the policies which exist at that time.
+
+## Version history
+
+Version 1, 11 March 2026 - first release of the service for pilot GP surgeries.

--- a/app/prototype_v4/content/privacy.md
+++ b/app/prototype_v4/content/privacy.md
@@ -1,0 +1,129 @@
+---
+title: NHS check if you need a lung scan privacy policy
+---
+
+## Who we are
+
+NHS England is running a pilot of the _check if you need a lung scan_ digital service.
+
+## Why we use your data
+
+We use your information to evaluate whether a digital questionnaire can safely and effectively support lung cancer screening alongside the existing telephone service.
+
+## What data we use
+
+This includes information you provide in the questionnaire, limited details from NHS login, and (if you complete both routes) responses from the telephone screening so they can be compared.
+
+## Your choice
+
+Taking part is voluntary. You can choose not to take part or withdraw at any time. This will not affect your NHS care.
+
+## How we protect your data
+
+Your data is kept secure, access is restricted, and personal identifiers are removed once analysis is complete.
+
+## More information
+
+Read the full privacy notice below to understand how your data is used, shared, stored, and what your rights are.
+
+### 1\. About this service
+
+NHS check if you need a lung scan is a pilot by NHS England and allows you to complete a lung health check online before you complete your phone appointment. The pilot is designed to evaluate whether a digital questionnaire can operate as effectively as the existing telephone based lung cancer screening service.
+
+The pilot is for service evaluation purposes only and does not form part of routine clinical care.
+
+### 2\. Who we are
+
+**Data Controller:** NHS England
+
+NHS England is responsible for deciding how and why your personal data is used as part of this pilot.
+
+### 3\. What data we collect
+
+If you choose to take part, we may collect:
+
+- NHS number
+- Name
+- Email address
+
+This information is provided through NHS login to allow secure access.
+
+Information you provide in the questionnaire:
+
+- Date of birth
+- Smoking history
+- Height and weight
+- Sex at birth and gender identity
+- Ethnicity
+- Education level
+- Relevant health, lifestyle, and family history information
+
+When you complete the telephone screening, NHS England receives the telephone responses **so they can be compared with the digital responses** as part of the evaluation.
+
+On completion of both the digital service and phone screening appointment, your name and email address will be used to issue a participation voucher.
+
+### 4\. How we use your information
+
+We use your information to:
+
+- Evaluate whether the digital questionnaire works as safely and accurately as the telephone screening
+- Compare digital and telephone screening responses
+- Understand clarity, usability, and accessibility of the digital service
+- Inform decisions about future service design
+
+We do not use your information to:
+
+- Provide diagnoses
+- Make clinical decisions
+- Replace existing screening pathways
+
+Participation in the pilot is voluntary. Where you choose to take part, we rely on your consent to:
+
+- participate in the digital pilot
+- allow comparison of digital and telephone screening responses
+- administer participation incentives where applicable
+
+You can withdraw from the pilot at any time without affecting your NHS care.
+
+### 5\. Who we share your information with
+
+Your information may be shared with:
+
+- **InHealth**, to enable comparison between digital and telephone screening responses
+- **NHS England technical and analysis teams**, limited to staff who need access to support the pilot
+- **Edenred**, where applicable, to issue participation vouchers (name and email address only)
+
+We do not sell your data or use it for marketing.
+
+### 6\. How long information is kept
+
+How long we keep your information:
+
+- Identifiable pilot data is kept only for the duration of the pilot and up to **three months afterwards**
+- Personal identifiers are removed once analysis is complete
+- An anonymised and aggregated dataset may be retained for up to **10 years** to support service evaluation and regulatory requirements
+- All data is managed in line with the **NHS Records Management Code of Practice**
+
+### 7\. The law and your information
+
+The law allows the NHS to use information:
+
+- to invite people for screening
+- to keep screening services safe and effective
+
+You can find out more [here](#).
+
+### 8\. Your rights and getting help
+
+You have rights over your personal information.
+
+These include the right to:
+
+- ask what information the NHS holds about you
+- ask for a copy of your screening results
+
+If you want to access your screening results, contact your GP or local screening service.
+
+### 9\. Ask a question or find out more
+
+If you have a general question about using the NHS check if you need a lung scan, you can contact us by email at: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)

--- a/app/prototype_v4/content/privacy.md
+++ b/app/prototype_v4/content/privacy.md
@@ -1,10 +1,10 @@
 ---
-title: NHS check if you need a lung scan privacy policy
+title: NHS {{ serviceName | lower }} privacy policy
 ---
 
 ## Who we are
 
-NHS England is running a pilot of the _check if you need a lung scan_ digital service.
+NHS England is running a pilot of the _{{ serviceName | lower }}_ digital service.
 
 ## Why we use your data
 
@@ -28,7 +28,7 @@ Read the full privacy notice below to understand how your data is used, shared, 
 
 ### 1\. About this service
 
-NHS check if you need a lung scan is a pilot by NHS England and allows you to complete a lung health check online before you complete your phone appointment. The pilot is designed to evaluate whether a digital questionnaire can operate as effectively as the existing telephone based lung cancer screening service.
+NHS {{ serviceName | lower }} is a pilot by NHS England and allows you to complete a lung health check online before you complete your phone appointment. The pilot is designed to evaluate whether a digital questionnaire can operate as effectively as the existing telephone based lung cancer screening service.
 
 The pilot is for service evaluation purposes only and does not form part of routine clinical care.
 
@@ -126,4 +126,4 @@ If you want to access your screening results, contact your GP or local screening
 
 ### 9\. Ask a question or find out more
 
-If you have a general question about using the NHS check if you need a lung scan, you can contact us by email at: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+If you have a general question about using the NHS {{ serviceName | lower }}, you can contact us by email at: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)

--- a/app/prototype_v4/content/privacy.md
+++ b/app/prototype_v4/content/privacy.md
@@ -126,4 +126,4 @@ If you want to access your screening results, contact your GP or local screening
 
 ### 9\. Ask a question or find out more
 
-If you have a general question about using the NHS {{ serviceName | lower }}, you can contact us by email at: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+If you have a general question about using the NHS {{ serviceName | lower }}, you can contact us by email at: {{ serviceEmail }}

--- a/app/prototype_v4/content/terms.md
+++ b/app/prototype_v4/content/terms.md
@@ -1,12 +1,12 @@
 ---
-title: NHS check if you need a lung scan terms of use
+title: NHS {{ serviceName | lower }} terms of use
 ---
 
 Version 4, 25 March 2026
 
 ## 1\. Introduction
 
-1.1. We (NHS England) have developed a digital service called NHS check if you need a lung scan. This is a digital way to access [NHS lung cancer screening](#). This service is currently in pilot so is only available in certain areas and if your GP surgery is participating in the pilot.
+1.1. We (NHS England) have developed a digital service called NHS {{ serviceName | lower }}. This is a digital way to access [NHS lung cancer screening](#). This service is currently in pilot so is only available in certain areas and if your GP surgery is participating in the pilot.
 
 1.2. This service will not provide you with any results or information in relation to the lung cancer screening, you will need to complete your lung cancer screening by phone to receive a result.
 
@@ -16,25 +16,25 @@ Version 4, 25 March 2026
 
 ## 2\. When these terms apply
 
-2.1. Please read these terms of use and our [privacy policy](#), [cookies policy](#) and [accessibility statement](#). By continuing to use the NHS check if you need a lung scan, you agree to be bound by these terms.
+2.1. Please read these terms of use and our [privacy policy](#), [cookies policy](#) and [accessibility statement](#). By continuing to use the NHS {{ serviceName | lower }}, you agree to be bound by these terms.
 
 ## 3\. How to use the NHS check if you need 2 lung scan
 
-3.1. To use NHS check if you need a lung scan, your GP must be participating in the pilot. Your GP will send you a letter and an SMS with a link to access the NHS check if you need a lung scan pilot service in a web browser.
+3.1. To use NHS {{ serviceName | lower }}, your GP must be participating in the pilot. Your GP will send you a letter and an SMS with a link to access the NHS {{ serviceName | lower }} pilot service in a web browser.
 
-3.2. To use the NHS check if you need a lung scan you need an NHS Login account with a medium level of identity verification. If you do not have an account or a medium level of identity verification, you will be able to set this up as part of your application. [Find out more about NHS login](#).
+3.2. To use the NHS {{ serviceName | lower }} you need an NHS Login account with a medium level of identity verification. If you do not have an account or a medium level of identity verification, you will be able to set this up as part of your application. [Find out more about NHS login](#).
 
-3.3. You are responsible for making all arrangements necessary for you to access the NHS check if you need a lung scan, including but not limited to:
+3.3. You are responsible for making all arrangements necessary for you to access the NHS {{ serviceName | lower }}, including but not limited to:
 
 - a secure internet connection (see [Cyber Aware website](#))
 - an appropriate device, operating system and browser
-- using your own virus protection software (and regularly updating it) when accessing and using the NHS check if you need a lung scan
+- using your own virus protection software (and regularly updating it) when accessing and using the NHS {{ serviceName | lower }}
 
 ## 4\. Details about the NHS check if you nee2 a lung scan
 
 4.1. If you download, print or export any of your submitted information, you are responsible for ensuring that this is held securely, and we will not be liable for any associated disclosure of sensitive and personal data.
 
-4.2. The NHS check if you need a lung scan:
+4.2. The NHS {{ serviceName | lower }}:
 
 - is not a substitute for seeking medical advice - always follow any medical advice given by your healthcare professionals
 - does not provide medical or clinical diagnostic services
@@ -42,23 +42,23 @@ Version 4, 25 March 2026
 
 ## 5\. Ending your use of the NHS check if yo2 need a lung scan
 
-5.1. You may stop using the NHS check if you need a lung scan at any time. If you fail to complete your NHS check if you need a lung scan within a set period of time your data will automatically be deleted. More information on how long your information is kept is in the [privacy policy](#).
+5.1. You may stop using the NHS {{ serviceName | lower }} at any time. If you fail to complete your NHS {{ serviceName | lower }} within a set period of time your data will automatically be deleted. More information on how long your information is kept is in the [privacy policy](#).
 
 ## 6\. Your right to use the NHS check if yo2 need a lung scan
 
-6.1. We own or have the right to use all intellectual property rights used for the provision of the NHS check if you need a lung scan, including rights in copyright, patents, database rights, trademarks and other intellectual property rights, ("NHS IPR").
+6.1. We own or have the right to use all intellectual property rights used for the provision of the NHS {{ serviceName | lower }}, including rights in copyright, patents, database rights, trademarks and other intellectual property rights, ("NHS IPR").
 
 6.2. Unless permitted by law or under these terms, you will:
 
-- not copy the NHS check if you need a lung scan or any NHS IPR, except where such copying is incidental to normal use
-- not rent, lease, sub-license, loan, translate, merge, adapt or modify the NHS check if you need a lung scan or any NHS IPR
-- not combine or incorporate the NHS check if you need a lung scan in any other programmes or services
-- not disassemble, decompile, reverse-engineer or create derivative works based on the whole or any part of the NHS check if you need a lung scan or other NHS IPR
-- comply with all technology control or export laws that apply to the technology used by the NHS check if you need a lung scan or any other NHS IPR
+- not copy the NHS {{ serviceName | lower }} or any NHS IPR, except where such copying is incidental to normal use
+- not rent, lease, sub-license, loan, translate, merge, adapt or modify the NHS {{ serviceName | lower }} or any NHS IPR
+- not combine or incorporate the NHS {{ serviceName | lower }} in any other programmes or services
+- not disassemble, decompile, reverse-engineer or create derivative works based on the whole or any part of the NHS {{ serviceName | lower }} or other NHS IPR
+- comply with all technology control or export laws that apply to the technology used by the NHS {{ serviceName | lower }} or any other NHS IPR
 
 ## 7\. Prohibited uses
 
-7.1. You may not use the NHS check if you need a lung scan:
+7.1. You may not use the NHS {{ serviceName | lower }}:
 
 - to collect any data or attempt to decipher any transmissions to or from our servers
 - in a way that could damage, disable, overburden, impair or compromise our systems or security
@@ -76,33 +76,33 @@ Version 4, 25 March 2026
 
 ## 8\. Our liability to you
 
-8.1. Although we make reasonable efforts to provide, maintain and update the NHS check if you need a lung scan it is provided "as is" and, to the extent permitted by law, we make no representations, warranties or guarantees, whether express or implied (including but not limited to the implied warranties of satisfactory quality and fitness for a particular purpose), that the NHS check if you need a lung scan:
+8.1. Although we make reasonable efforts to provide, maintain and update the NHS {{ serviceName | lower }} it is provided "as is" and, to the extent permitted by law, we make no representations, warranties or guarantees, whether express or implied (including but not limited to the implied warranties of satisfactory quality and fitness for a particular purpose), that the NHS {{ serviceName | lower }}:
 
 - is accurate, complete or up-to-date
 - will meet your particular requirements or needs
 - will always be available, error free, uninterrupted or free of viruses
 
-8.2. We are not responsible for external links to or from the NHS check if you need a lung scan and cannot guarantee these will always work.
+8.2. We are not responsible for external links to or from the NHS {{ serviceName | lower }} and cannot guarantee these will always work.
 
 8.3. Nothing in these terms excludes or limits our liability for:
 
 - death or personal injury arising from our negligence
 - fraud or fraudulent misrepresentation
-- any loss or damage to a device or digital content belonging to you, if you can show that a) this was caused by NHS check if you need a lung scan and b) we failed use to use reasonable skill and care to prevent this
+- any loss or damage to a device or digital content belonging to you, if you can show that a) this was caused by NHS {{ serviceName | lower }} and b) we failed use to use reasonable skill and care to prevent this
 - any other liability that cannot be excluded or limited under English law
 
 8.4. Subject to clause 8.3 of these terms, we will not be liable or responsible to you or any other person for:
 
 - any harm, loss or damage suffered where this is not caused by i) our negligence or ii) our breach of these terms
-- any loss or damage arising from an inability to access or use the NHS check if you need a lung scan in whole or in part
+- any loss or damage arising from an inability to access or use the NHS {{ serviceName | lower }} in whole or in part
 - any business loss (including but not limited to loss of profits, revenue, contracts, anticipated savings, data, goodwill or wasted expenditure)
-- any indirect or consequential losses that were not foreseeable to both you and us when you commenced using the NHS check if you need a lung scan (loss or damage is "foreseeable" if it was an obvious consequence of our breach or if it was recognised by you and us at the time we entered into the contract created by your use of the NHS check if you need a lung scan)
+- any indirect or consequential losses that were not foreseeable to both you and us when you commenced using the NHS {{ serviceName | lower }} (loss or damage is "foreseeable" if it was an obvious consequence of our breach or if it was recognised by you and us at the time we entered into the contract created by your use of the NHS {{ serviceName | lower }})
 
 8.5. This clause 8 does not affect any legal rights you may have as a consumer in relation to defective services or software. Advice about your legal rights is available from your local Citizen's Advice or Trading Standards Office.
 
 ## 9\. General
 
-9.1. These terms, any instructions in the service, and any other terms or policies referenced, set out the entire agreement between you and us in respect of your use of the NHS check if you need a lung scan.
+9.1. These terms, any instructions in the service, and any other terms or policies referenced, set out the entire agreement between you and us in respect of your use of the NHS {{ serviceName | lower }}.
 
 9.2. These terms do not give any rights to any third party to enforce any of these terms.
 
@@ -110,4 +110,4 @@ Version 4, 25 March 2026
 
 9.4. Even if we delay in enforcing these terms, we can still enforce them later.
 
-9.5. The laws of England shall apply exclusively to these terms and all matters relating to use of the NHS check if you need a lung scan, and any dispute shall be subject to the exclusive jurisdiction of the courts of England.
+9.5. The laws of England shall apply exclusively to these terms and all matters relating to use of the NHS {{ serviceName | lower }}, and any dispute shall be subject to the exclusive jurisdiction of the courts of England.

--- a/app/prototype_v4/content/terms.md
+++ b/app/prototype_v4/content/terms.md
@@ -12,7 +12,7 @@ Version 4, 25 March 2026
 
 1.3. To find out more about who we are and our role, visit the [NHS England website](#).
 
-1.4. Contacting us: if you have any questions about the service, contact us by email: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+1.4. Contacting us: if you have any questions about the service, contact us by email: {{ serviceEmail }}
 
 ## 2\. When these terms apply
 

--- a/app/prototype_v4/content/terms.md
+++ b/app/prototype_v4/content/terms.md
@@ -1,0 +1,113 @@
+---
+title: NHS check if you need a lung scan terms of use
+---
+
+Version 4, 25 March 2026
+
+## 1\. Introduction
+
+1.1. We (NHS England) have developed a digital service called NHS check if you need a lung scan. This is a digital way to access [NHS lung cancer screening](#). This service is currently in pilot so is only available in certain areas and if your GP surgery is participating in the pilot.
+
+1.2. This service will not provide you with any results or information in relation to the lung cancer screening, you will need to complete your lung cancer screening by phone to receive a result.
+
+1.3. To find out more about who we are and our role, visit the [NHS England website](#).
+
+1.4. Contacting us: if you have any questions about the service, contact us by email: [england.digitallungcancerscreening@nhs.net](mailto:england.digitallungcancerscreening@nhs.net)
+
+## 2\. When these terms apply
+
+2.1. Please read these terms of use and our [privacy policy](#), [cookies policy](#) and [accessibility statement](#). By continuing to use the NHS check if you need a lung scan, you agree to be bound by these terms.
+
+## 3\. How to use the NHS check if you need 2 lung scan
+
+3.1. To use NHS check if you need a lung scan, your GP must be participating in the pilot. Your GP will send you a letter and an SMS with a link to access the NHS check if you need a lung scan pilot service in a web browser.
+
+3.2. To use the NHS check if you need a lung scan you need an NHS Login account with a medium level of identity verification. If you do not have an account or a medium level of identity verification, you will be able to set this up as part of your application. [Find out more about NHS login](#).
+
+3.3. You are responsible for making all arrangements necessary for you to access the NHS check if you need a lung scan, including but not limited to:
+
+- a secure internet connection (see [Cyber Aware website](#))
+- an appropriate device, operating system and browser
+- using your own virus protection software (and regularly updating it) when accessing and using the NHS check if you need a lung scan
+
+## 4\. Details about the NHS check if you nee2 a lung scan
+
+4.1. If you download, print or export any of your submitted information, you are responsible for ensuring that this is held securely, and we will not be liable for any associated disclosure of sensitive and personal data.
+
+4.2. The NHS check if you need a lung scan:
+
+- is not a substitute for seeking medical advice - always follow any medical advice given by your healthcare professionals
+- does not provide medical or clinical diagnostic services
+- does not arrange or guarantee further healthcare treatment. You remain responsible for booking further healthcare treatment via the phone service as directed by your GP.
+
+## 5\. Ending your use of the NHS check if yo2 need a lung scan
+
+5.1. You may stop using the NHS check if you need a lung scan at any time. If you fail to complete your NHS check if you need a lung scan within a set period of time your data will automatically be deleted. More information on how long your information is kept is in the [privacy policy](#).
+
+## 6\. Your right to use the NHS check if yo2 need a lung scan
+
+6.1. We own or have the right to use all intellectual property rights used for the provision of the NHS check if you need a lung scan, including rights in copyright, patents, database rights, trademarks and other intellectual property rights, ("NHS IPR").
+
+6.2. Unless permitted by law or under these terms, you will:
+
+- not copy the NHS check if you need a lung scan or any NHS IPR, except where such copying is incidental to normal use
+- not rent, lease, sub-license, loan, translate, merge, adapt or modify the NHS check if you need a lung scan or any NHS IPR
+- not combine or incorporate the NHS check if you need a lung scan in any other programmes or services
+- not disassemble, decompile, reverse-engineer or create derivative works based on the whole or any part of the NHS check if you need a lung scan or other NHS IPR
+- comply with all technology control or export laws that apply to the technology used by the NHS check if you need a lung scan or any other NHS IPR
+
+## 7\. Prohibited uses
+
+7.1. You may not use the NHS check if you need a lung scan:
+
+- to collect any data or attempt to decipher any transmissions to or from our servers
+- in a way that could damage, disable, overburden, impair or compromise our systems or security
+- to transmit any material that is insulting or offensive
+- in a way that interferes with other users
+- in any unlawful manner or for any unlawful purpose
+- in a manner that is improper use or inconsistent with these terms
+- to act fraudulently or maliciously by seeking to access or add data to another patient's GP record
+- to transmit, send or upload any data that contains viruses, Trojan horses, worms, spyware or any other harmful programs designed to adversely affect the operation of computer software or hardware
+- in connection with any kind of denial of service attack
+- on any device or operating system that has been modified outside the mobile device or operating system vendor supported or warranted configurations. This includes devices that have been "jail-broken" or "rooted"
+- with someone else's NHS login account
+
+7.2. If you do any of the above acts you may also be committing a criminal offence, and we will report any such activity to the relevant law enforcement authorities. We will co-operate with those authorities by disclosing your identity to them.
+
+## 8\. Our liability to you
+
+8.1. Although we make reasonable efforts to provide, maintain and update the NHS check if you need a lung scan it is provided "as is" and, to the extent permitted by law, we make no representations, warranties or guarantees, whether express or implied (including but not limited to the implied warranties of satisfactory quality and fitness for a particular purpose), that the NHS check if you need a lung scan:
+
+- is accurate, complete or up-to-date
+- will meet your particular requirements or needs
+- will always be available, error free, uninterrupted or free of viruses
+
+8.2. We are not responsible for external links to or from the NHS check if you need a lung scan and cannot guarantee these will always work.
+
+8.3. Nothing in these terms excludes or limits our liability for:
+
+- death or personal injury arising from our negligence
+- fraud or fraudulent misrepresentation
+- any loss or damage to a device or digital content belonging to you, if you can show that a) this was caused by NHS check if you need a lung scan and b) we failed use to use reasonable skill and care to prevent this
+- any other liability that cannot be excluded or limited under English law
+
+8.4. Subject to clause 8.3 of these terms, we will not be liable or responsible to you or any other person for:
+
+- any harm, loss or damage suffered where this is not caused by i) our negligence or ii) our breach of these terms
+- any loss or damage arising from an inability to access or use the NHS check if you need a lung scan in whole or in part
+- any business loss (including but not limited to loss of profits, revenue, contracts, anticipated savings, data, goodwill or wasted expenditure)
+- any indirect or consequential losses that were not foreseeable to both you and us when you commenced using the NHS check if you need a lung scan (loss or damage is "foreseeable" if it was an obvious consequence of our breach or if it was recognised by you and us at the time we entered into the contract created by your use of the NHS check if you need a lung scan)
+
+8.5. This clause 8 does not affect any legal rights you may have as a consumer in relation to defective services or software. Advice about your legal rights is available from your local Citizen's Advice or Trading Standards Office.
+
+## 9\. General
+
+9.1. These terms, any instructions in the service, and any other terms or policies referenced, set out the entire agreement between you and us in respect of your use of the NHS check if you need a lung scan.
+
+9.2. These terms do not give any rights to any third party to enforce any of these terms.
+
+9.3. Each of the clauses and sub-clauses of these terms operates separately. If any part is determined to be invalid or unenforceable it will be superseded by a valid and enforceable provision that most closely matches the intent of the original and all other terms shall continue in effect.
+
+9.4. Even if we delay in enforcing these terms, we can still enforce them later.
+
+9.5. The laws of England shall apply exclusively to these terms and all matters relating to use of the NHS check if you need a lung scan, and any dispute shall be subject to the exclusive jurisdiction of the courts of England.

--- a/app/prototype_v4/controllers/content.js
+++ b/app/prototype_v4/controllers/content.js
@@ -4,7 +4,28 @@ const matter = require('gray-matter')
 
 const contentDirectory = path.join(__dirname, '..', 'content')
 
-const renderContent = (fileName) => (_req, res, next) => {
+const renderNunjucksData = (value, nunjucks, context) => {
+  if (typeof value === 'string') {
+    return nunjucks.renderString(value, context)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => renderNunjucksData(item, nunjucks, context))
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        renderNunjucksData(item, nunjucks, context)
+      ])
+    )
+  }
+
+  return value
+}
+
+const renderContent = (fileName) => (req, res, next) => {
   const filePath = path.join(contentDirectory, `${fileName}.md`)
 
   fs.readFile(filePath, 'utf8', (error, file) => {
@@ -12,16 +33,34 @@ const renderContent = (fileName) => (_req, res, next) => {
       return next(error)
     }
 
-    const parsed = matter(file)
+    let contentData
+    let renderedMarkdown
 
-    res.render('prototype_v4/views/content/show', {
-      content: parsed.content,
-      contentData: {
+    try {
+      const parsed = matter(file)
+      const nunjucks = req.app.get('nunjucksEnv')
+      const renderedData = renderNunjucksData(parsed.data, nunjucks, res.locals)
+
+      contentData = {
         contents: {
           items: []
         },
-        ...parsed.data
+        ...renderedData
       }
+
+      const templateContext = {
+        ...res.locals,
+        contentData
+      }
+
+      renderedMarkdown = nunjucks.renderString(parsed.content, templateContext)
+    } catch (error) {
+      return next(error)
+    }
+
+    res.render('prototype_v4/views/content/show', {
+      content: renderedMarkdown,
+      contentData
     })
   })
 }

--- a/app/prototype_v4/controllers/content.js
+++ b/app/prototype_v4/controllers/content.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const path = require('path')
+const matter = require('gray-matter')
+
+const contentDirectory = path.join(__dirname, '..', 'content')
+
+const renderContent = (fileName) => (_req, res, next) => {
+  const filePath = path.join(contentDirectory, `${fileName}.md`)
+
+  fs.readFile(filePath, 'utf8', (error, file) => {
+    if (error) {
+      return next(error)
+    }
+
+    const parsed = matter(file)
+
+    res.render('prototype_v4/views/content/show', {
+      content: parsed.content,
+      contentData: {
+        contents: {
+          items: []
+        },
+        ...parsed.data
+      }
+    })
+  })
+}
+
+exports.accessibility = renderContent('accessibility')
+exports.contact = renderContent('contact')
+exports.cookies = renderContent('cookies')
+exports.privacy = renderContent('privacy')
+exports.terms = renderContent('terms')

--- a/app/prototype_v4/controllers/error.js
+++ b/app/prototype_v4/controllers/error.js
@@ -1,0 +1,11 @@
+exports.pageNotFound = (req, res) => {
+  res.status(404).render('prototype_v4/views/errors/404')
+}
+
+exports.unexpectedError = (req, res) => {
+  res.status(500).render('prototype_v4/views/errors/500')
+}
+
+exports.serviceUnavailable = (req, res) => {
+  res.status(503).render('prototype_v4/views/errors/503')
+}

--- a/app/prototype_v4/routes.js
+++ b/app/prototype_v4/routes.js
@@ -1,0 +1,78 @@
+const express = require('express')
+const fs = require('fs')
+const path = require('path')
+const router = express.Router()
+
+const version = 'v4'
+const viewsDirectory = path.join(__dirname, 'views')
+
+const view = (template) => {
+  return `prototype_${version}/views/${template}`
+}
+
+const hasView = (template) => {
+  if (!template || template.includes('..')) {
+    return false
+  }
+
+  const templatePath = path.join(viewsDirectory, `${template}.html`)
+  return templatePath.startsWith(viewsDirectory) && fs.existsSync(templatePath)
+}
+
+/// ------------------------------------------------------------------------ ///
+/// Controller modules - used for routing
+/// ------------------------------------------------------------------------ ///
+
+const contentController = require('./controllers/content')
+const errorController = require('./controllers/error')
+
+/// ------------------------------------------------------------------------ ///
+///
+/// ------------------------------------------------------------------------ ///
+
+router.get('/prototype_v4', (_req, res) => {
+  res.render(view('index'))
+})
+
+/// ------------------------------------------------------------------------ ///
+/// Static pages
+/// ------------------------------------------------------------------------ ///
+
+router.get('/prototype_v4/accessibility-statement', contentController.accessibility)
+
+router.get('/prototype_v4/contact-us', contentController.contact)
+
+router.get('/prototype_v4/cookies', contentController.cookies)
+
+router.get('/prototype_v4/privacy-policy', contentController.privacy)
+
+router.get('/prototype_v4/terms-of-use', contentController.terms)
+
+/// ------------------------------------------------------------------------ ///
+/// Error pages
+/// ------------------------------------------------------------------------ ///
+
+router.get('/prototype_v4/404', errorController.pageNotFound)
+router.get('/prototype_v4/page-not-found', errorController.pageNotFound)
+
+router.get('/prototype_v4/500', errorController.unexpectedError)
+router.get('/prototype_v4/server-error', errorController.unexpectedError)
+
+router.get('/prototype_v4/503', errorController.serviceUnavailable)
+router.get('/prototype_v4/service-unavailable', errorController.serviceUnavailable)
+
+/// ------------------------------------------------------------------------ ///
+/// Add your routes above
+/// ------------------------------------------------------------------------ ///
+
+router.get(/^\/prototype_v4\/(.+)$/, (req, res, next) => {
+  const template = req.params[0]
+
+  if (!hasView(template)) {
+    return errorController.pageNotFound(req, res)
+  }
+
+  res.render(view(template))
+})
+
+module.exports = router

--- a/app/prototype_v4/views/content/show.html
+++ b/app/prototype_v4/views/content/show.html
@@ -1,0 +1,29 @@
+{% extends "prototype_v4/views/layouts/main.html" %}
+
+{% set title = contentData.title %}
+
+{% block content %}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">{{ title }}</h1>
+
+      {% if contentData.contents.items and contentData.contents.items.length %}
+        <h2 class="nhsuk-heading-s">Contents</h2>
+
+        <ul class="nhsuk-list app-list--dash course-contents nhsuk-u-margin-bottom-8">
+          {% for item in contentData.contents.items %}
+            <li><a class="nhsuk-link" href="{{ item.href }}">{{ item.text }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+
+      <div class="app-markdown">
+        {{ content | markdownToHtml | safe }}
+      </div>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/prototype_v4/views/errors/404.html
+++ b/app/prototype_v4/views/errors/404.html
@@ -8,7 +8,7 @@
       <h1 class="nhsuk-heading-l">{{ title }}</h1>
       <p class="nhsuk-body">If you typed a web address, check it is correct.</p>
       <p class="nhsuk-body">If you pasted the web address, check you copied the entire address.</p>
-      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:england.digitallungcancerscreening@nhs.net">england.digitallungcancerscreening@nhs.net</a>.</p>
+      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:{{ serviceEmail }}">{{ serviceEmail }}</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/prototype_v4/views/errors/404.html
+++ b/app/prototype_v4/views/errors/404.html
@@ -1,0 +1,14 @@
+{% extends "prototype_v4/views/layouts/main.html" %}
+
+{% set title = "Page not found" %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-l">{{ title }}</h1>
+      <p class="nhsuk-body">If you typed a web address, check it is correct.</p>
+      <p class="nhsuk-body">If you pasted the web address, check you copied the entire address.</p>
+      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:england.digitallungcancerscreening@nhs.net">england.digitallungcancerscreening@nhs.net</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/prototype_v4/views/errors/500.html
+++ b/app/prototype_v4/views/errors/500.html
@@ -11,7 +11,7 @@
       <h1 class="nhsuk-heading-l">{{ title }}</h1>
       <p class="nhsuk-body">Try again later.</p>
       <p class="nhsuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
-      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:england.digitallungcancerscreening@nhs.net">england.digitallungcancerscreening@nhs.net</a>.</p>
+      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:{{ serviceEmail }}">{{ serviceEmail }}</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/prototype_v4/views/errors/500.html
+++ b/app/prototype_v4/views/errors/500.html
@@ -1,0 +1,17 @@
+{% extends "prototype_v4/views/layouts/main.html" %}
+
+{% set hidePhaseBanner = true %}
+{% set hideFooterLinks = true %}
+
+{% set title = "Sorry, there’s a problem with the service" %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-l">{{ title }}</h1>
+      <p class="nhsuk-body">Try again later.</p>
+      <p class="nhsuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:england.digitallungcancerscreening@nhs.net">england.digitallungcancerscreening@nhs.net</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/prototype_v4/views/errors/503.html
+++ b/app/prototype_v4/views/errors/503.html
@@ -1,0 +1,17 @@
+{% extends "prototype_v4/views/layouts/main.html" %}
+
+{% set hidePhaseBanner = true %}
+{% set hideFooterLinks = true %}
+
+{% set title = "Sorry, the service is unavailable" %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-l">{{ title }}</h1>
+      <p class="nhsuk-body">You will be able to use the service from 3pm on Tuesday, 5 May 2026.</p>
+      <p class="nhsuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:england.digitallungcancerscreening@nhs.net">england.digitallungcancerscreening@nhs.net</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/prototype_v4/views/errors/503.html
+++ b/app/prototype_v4/views/errors/503.html
@@ -11,7 +11,7 @@
       <h1 class="nhsuk-heading-l">{{ title }}</h1>
       <p class="nhsuk-body">You will be able to use the service from 3pm on Tuesday, 5 May 2026.</p>
       <p class="nhsuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
-      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:england.digitallungcancerscreening@nhs.net">england.digitallungcancerscreening@nhs.net</a>.</p>
+      <p class="nhsuk-body">If you have any questions, email <a class="nhsuk-link" href="mailto:{{ serviceEmail }}">{{ serviceEmail }}</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/prototype_v4/views/index.html
+++ b/app/prototype_v4/views/index.html
@@ -1,10 +1,12 @@
 {% extends "prototype_v4/views/layouts/main.html" %}
 
+{% set title = "Help us test a new online service" %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Help us test a new online service</h1>
+      <h1 class="nhsuk-heading-l">{{ title }}</h1>
 
       <p class="nhsuk-body">We are testing a new online questionnaire for lung cancer screening. This service will ask you some questions about your medical history and lifestyle.</p>
 

--- a/app/prototype_v4/views/index.html
+++ b/app/prototype_v4/views/index.html
@@ -1,0 +1,54 @@
+{% extends "prototype_v4/views/layouts/main.html" %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Help us test a new online service</h1>
+
+      <p class="nhsuk-body">We are testing a new online questionnaire for lung cancer screening. This service will ask you some questions about your medical history and lifestyle.</p>
+
+      <p class="nhsuk-body">This online service cannot currently recommend if you need a lung scan. Once you have completed the online service you will need to call us to repeat the questionnaire by phone.</p>
+
+      <p class="nhsuk-body">The answers you submit will not be shared with your patient care advisor during your phone appointment, or with your GP.</p>
+
+      <p class="nhsuk-body">As a thank you for testing the online service, we will offer you a £10 voucher once you have completed both the online service and your phone appointment.</p>
+
+      <h2 class="nhsuk-heading-m">The benefits of lung cancer screening</h2>
+
+      <p class="nhsuk-body">Your risk of lung cancer increases as you get older. Screening aims to find lung cancer early, sometimes before you have symptoms. Early diagnosis can make lung cancer more treatable and make treatment more successful.</p>
+
+      <p class="nhsuk-body">You are eligible for lung cancer screening if you are:</p>
+
+      <ul class="nhsuk-list nhsuk-list--bullet">
+        <li>aged between 55 and 74</li>
+        <li>registered with a GP surgery</li>
+        <li>someone who smokes or used to smoke</li>
+      </ul>
+
+      <h2 class="nhsuk-heading-m">What to expect in the online service</h2>
+
+      <p class="nhsuk-body">We will ask you questions about:</p>
+
+      <ul class="nhsuk-list nhsuk-list--bullet">
+        <li>your height and weight</li>
+        <li>your ethnicity</li>
+        <li>your education</li>
+        <li>if you have ever had a cancer diagnosis</li>
+        <li>if your parents, siblings, or children have ever had a lung cancer diagnosis</li>
+        <li>your smoking habits</li>
+      </ul>
+
+      {{ button({
+        text: "Continue",
+        href: "start-journey",
+        classes: "nhsuk-button--login"
+      }) }}
+
+      <h2 class="nhsuk-heading-m">If you do not want to test the online service</h2>
+
+      <p class="nhsuk-body">You should call us on <a href="tel:02075554444" class="nhsuk-link">0207 555 444</a> to complete the questionnaire by phone.</p>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/prototype_v4/views/layouts/main.html
+++ b/app/prototype_v4/views/layouts/main.html
@@ -1,0 +1,114 @@
+<!--
+  This is the main layout where you can:
+    - change the header and footer
+    - add custom CSS and JavaScript
+-->
+<!-- Extends the prototype kit template which in turn extends the NHS.UK frontend template -->
+{% extends "prototype-kit-template.njk" %}
+
+{% block head %}
+ <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
+<link href="/assets/sass/main.css" rel="stylesheet">
+{% endblock %}
+
+<!-- Set the page title -->
+{% block pageTitle %}
+{{ serviceName }} - NHS
+{% endblock %}
+
+<!-- Edit the header -->
+<!-- Header code examples can be found at https://service-manual.nhs.uk/design-system/components/header -->
+{% block header %}
+{{ header({
+  logo: {
+    href: "/",
+    ariaLabel: "Check if you need a lung scan"
+  },
+  service: {
+    text: "Check if you need a lung scan",
+    href: "/"
+  },
+  account: {
+    items: [
+      {
+        text: "Alex Smith",
+        href: "#",
+        icon: true
+      },
+      {
+        text: "Log out",
+        href: "/prototype_v4/"
+      }
+    ]
+  } if data['logged-in']
+}) }}
+
+<!-- Phase banner (inside header block) -->
+<div class="nhsuk-phase-banner">
+  <div class="nhsuk-width-container">
+    <div class="nhsuk-phase-banner__content">
+      {{ tag({
+        text: "Pilot",
+        classes: "nhsuk-tag--blue"
+      }) }}
+      <p class="nhsuk-phase-banner__text nhsuk-body-s">
+        We are testing a new service – your <a class="nhsuk-link" href="https://feedback.digital.nhs.uk/jfe/form/SV_d4MPGuH486oxASW" target="_blank" rel="noopener noreferrer">feedback</a> will help us to improve it.
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+<!-- Edit the footer -->
+<!-- Footer code examples can be found at https://service-manual.nhs.uk/design-system/components/footer -->
+{% block footer %}
+{{ footer({
+  meta: {
+    items: [
+      {
+        href: "/prototype_v4/accessibility-statement",
+        text: "Accessibility statement"
+      },
+      {
+        href: "/prototype_v4/contact-us",
+        text: "Contact us"
+      },
+      {
+        href: "/prototype_v4/cookies",
+        text: "Cookies"
+      },
+      {
+        href: "/prototype_v4/privacy-policy",
+        text: "Privacy policy"
+      },
+      {
+        href: "/prototype_v4/terms-of-use",
+        text: "Terms of use"
+      }
+    ]
+  }
+}) }}
+
+{# <div class="nhsuk-footer__testing-links">
+  <div class="nhsuk-width-container">
+    <h3 class="nhsuk-heading-m nhsuk-u-margin-top-5">For testing</h3>
+    <ul class="nhsuk-footer__list nhsuk-u-margin-bottom-5 nhsuk-u-padding-bottom-5">
+      <li class="nhsuk-footer__list-item">
+        <a class="nhsuk-footer__list-item-link nhsuk-u-font-weight-bold" href="/prototype_v4/index-allpages">Pages index</a>
+      </li>
+      <li class="nhsuk-footer__list-item">
+        <a class="nhsuk-footer__list-item-link nhsuk-u-font-weight-bold" href="/prototype_v4/skip-to-tobacco">Skip to tobacco - current smoker (testing)</a>
+      </li>
+      <li class="nhsuk-footer__list-item">
+        <a class="nhsuk-footer__list-item-link nhsuk-u-font-weight-bold" href="/prototype_v4/skip-to-tobacco-former">Skip to tobacco - former smoker (testing)</a>
+      </li>
+    </ul>
+  </div>
+</div> #}
+{% endblock %}
+
+{% block bodyEnd %}
+  {{ super() }}
+  <script type="module" src="/assets/javascript/main.js"></script>
+  {% block pageScripts %}{% endblock %}
+{% endblock %}

--- a/app/prototype_v4/views/layouts/main.html
+++ b/app/prototype_v4/views/layouts/main.html
@@ -13,7 +13,7 @@
 
 <!-- Set the page title -->
 {% block pageTitle %}
-{{ serviceName }} - NHS
+{{ "Error: " if errors | length }} {{- title + " - " if title | length }} {{- serviceName }} - NHS
 {% endblock %}
 
 <!-- Edit the header -->

--- a/app/prototype_v4/views/layouts/main.html
+++ b/app/prototype_v4/views/layouts/main.html
@@ -44,19 +44,21 @@
 }) }}
 
 <!-- Phase banner (inside header block) -->
-<div class="nhsuk-phase-banner">
-  <div class="nhsuk-width-container">
-    <div class="nhsuk-phase-banner__content">
-      {{ tag({
-        text: "Pilot",
-        classes: "nhsuk-tag--blue"
-      }) }}
-      <p class="nhsuk-phase-banner__text nhsuk-body-s">
-        We are testing a new service – your <a class="nhsuk-link" href="https://feedback.digital.nhs.uk/jfe/form/SV_d4MPGuH486oxASW" target="_blank" rel="noopener noreferrer">feedback</a> will help us to improve it.
-      </p>
+{% if not hidePhaseBanner %}
+  <div class="nhsuk-phase-banner">
+    <div class="nhsuk-width-container">
+      <div class="nhsuk-phase-banner__content">
+        {{ tag({
+          text: "Pilot",
+          classes: "nhsuk-tag--blue"
+        }) }}
+        <p class="nhsuk-phase-banner__text nhsuk-body-s">
+          We are testing a new service – your <a class="nhsuk-link" href="https://feedback.digital.nhs.uk/jfe/form/SV_d4MPGuH486oxASW" target="_blank" rel="noopener noreferrer">feedback</a> will help us to improve it.
+        </p>
+      </div>
     </div>
   </div>
-</div>
+{% endif %}
 {% endblock %}
 
 <!-- Edit the footer -->
@@ -87,7 +89,7 @@
       }
     ]
   }
-}) }}
+}) if not hideFooterLinks }}
 
 {# <div class="nhsuk-footer__testing-links">
   <div class="nhsuk-width-container">

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,6 +6,7 @@ const router = express.Router()
 router.use(require('./prototype_v1/routes'))
 router.use(require('./prototype_v2/routes'))
 router.use(require('./prototype_v3/routes'))
+router.use(require('./prototype_v4/routes'))
 
 // Add your routes here - above the module.exports line
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -27,7 +27,7 @@ Check if you need a lung scan
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
 
-    <!-- Prototype v4 -->
+    {# <!-- Prototype v4 -->
     <h2>Prototype version 4.0 - pilot</h2>
     <p class="nhsuk-body-s nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-2">Last updated: 5 May 2026</p>
     <p>Multiple changes have been made to v4, including major revisions to the tobacco smoking screens.</p>
@@ -36,7 +36,7 @@ Check if you need a lung scan
     </a>
 
     <!-- Section break -->
-    <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible">
+    <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible"> #}
 
     <!-- Prototype v3 -->
     <h2>Prototype version 3.0 - pre-pilot</h2>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -27,6 +27,17 @@ Check if you need a lung scan
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
 
+    <!-- Prototype v4 -->
+    <h2>Prototype version 4.0 - pilot</h2>
+    <p class="nhsuk-body-s nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-2">Last updated: 5 May 2026</p>
+    <p>Multiple changes have been made to v4, including major revisions to the tobacco smoking screens.</p>
+    <a class="nhsuk-button nhsuk-button--secondary" href="/prototype_v4/">
+      Open prototype
+    </a>
+
+    <!-- Section break -->
+    <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible">
+
     <!-- Prototype v3 -->
     <h2>Prototype version 3.0 - pre-pilot</h2>
     <p class="nhsuk-body-s nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-2">Last updated: 16 April 2026</p>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,0 +1,1 @@
+{% extends "layouts/home.html" %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "dependencies": {
         "gray-matter": "^4.0.3",
         "luxon": "^3.7.2",
-        "marked": "^18.0.3",
-        "marked-gfm-heading-id": "^4.1.4",
+        "markdown-it": "^14.1.1",
         "nhsuk-frontend": "^10.4.0",
         "nhsuk-prototype-kit": "^8.2.0"
       },
@@ -1700,7 +1699,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -2973,7 +2971,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4598,12 +4595,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5850,7 +5841,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -5950,7 +5940,6 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -6110,30 +6099,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/marked": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
-      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/marked-gfm-heading-id": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-4.1.4.tgz",
-      "integrity": "sha512-CspnvVfHSkb/znqdPS4jUR8HtCjq3M/DnrsJCrfLBLvdrgbemmoINKpeWKQYkBiXAoBGejw0cV7xzqrPdup3WA==",
-      "license": "MIT",
-      "dependencies": {
-        "github-slugger": "^2.0.0"
-      },
-      "peerDependencies": {
-        "marked": ">=13 <19"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6165,7 +6130,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -7770,7 +7734,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10110,7 +10073,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uid-safe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3",
+        "luxon": "^3.7.2",
         "marked": "^18.0.3",
         "marked-gfm-heading-id": "^4.1.4",
         "nhsuk-frontend": "^10.4.0",
@@ -5934,6 +5935,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/markdown-it": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "gray-matter": "^4.0.3",
+    "luxon": "^3.7.2",
     "marked": "^18.0.3",
     "marked-gfm-heading-id": "^4.1.4",
     "nhsuk-frontend": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "luxon": "^3.7.2",
-    "marked": "^18.0.3",
-    "marked-gfm-heading-id": "^4.1.4",
+    "markdown-it": "^14.1.1",
     "nhsuk-frontend": "^10.4.0",
     "nhsuk-prototype-kit": "^8.2.0"
   },


### PR DESCRIPTION
This PR sets up version 4 of the prototype, including:

- using `markdown-it` for Markdown parsing
- using `luxon` for dates
- setting up a `filters` directory for things like `markdown` and `date` filters
- organise the v4 routes, views and content
- added markdown content for static pages: accessibility, contact, cookies, privacy, and terms
- added `serviceUrl`, `serviceName` and `serviceTelephone` to app locals
- add error page content for: 404, 500, and 503 errors

This PR does not include question routing. That will be in a subsequent PR.

View deployment: https://lung-health-check-pr-62.herokuapp.com/