### PR TITLE
Setup prototype v4 past vs present smoking

### DIFF
--- a/app/prototype_v4/controllers/authentication.js
+++ b/app/prototype_v4/controllers/authentication.js
@@ -4,6 +4,7 @@ const view = (template) => {
 }
 
 exports.signIn_get = (req, res) => {
+  delete req.session.data
 
   res.render(view('authentication/sign-in'), {
     actions: {

--- a/app/prototype_v4/controllers/question.js
+++ b/app/prototype_v4/controllers/question.js
@@ -522,18 +522,29 @@ const getSmokingCurrentAmount = (type, answer = {}) => {
   return [quantity, period].filter(Boolean).join(' ')
 }
 
-const getSmokingChangeLabels = (type, answer = {}) => {
+const isPastSmokingType = (answers = {}, answer = {}) => {
+  return answers.smoker === 'yes_previous' || answer.smokingStatus === 'no'
+}
+
+const getSmokingChangeLabels = (type, answer = {}, isPast = false) => {
   const amount = getSmokingCurrentAmount(type, answer)
   const fewerLabel = type === 'rolling_tobacco' ? 'less' : 'fewer'
+  const defaultLabels = isPast
+    ? {
+        greater: 'Yes, I smoked more',
+        fewer: `Yes, I smoked ${fewerLabel}`,
+        no: 'No, it did not change'
+      }
+    : valueLabels.smokingChange
 
   if (!amount) {
-    return valueLabels.smokingChange
+    return defaultLabels
   }
 
   return {
-    ...valueLabels.smokingChange,
-    greater: `Yes, I used to smoke more than ${amount}`,
-    fewer: `Yes, I used to smoke ${fewerLabel} than ${amount}`
+    ...defaultLabels,
+    greater: `Yes, I ${isPast ? 'smoked' : 'used to smoke'} more than ${amount}`,
+    fewer: `Yes, I ${isPast ? 'smoked' : 'used to smoke'} ${fewerLabel} than ${amount}`
   }
 }
 
@@ -541,7 +552,48 @@ const getShishaSettingAnswer = (answer = {}, setting) => {
   return setting ? answer[setting] || {} : {}
 }
 
-const getSmokingStepHeading = (page, type, setting) => {
+const getPastSmokingHeading = (heading = '') => {
+  return heading
+    .replace('How often do you smoke', 'How often did you smoke')
+    .replace('How many cigarettes do you currently smoke', 'How many cigarettes did you smoke')
+    .replace('How much rolling tobacco do you currently smoke', 'How much rolling tobacco did you smoke')
+    .replace('How many full pipe loads do you currently smoke', 'How many full pipe loads did you smoke')
+    .replace('How many small cigars do you currently smoke', 'How many small cigars did you smoke')
+    .replace('How many medium cigars do you currently smoke', 'How many medium cigars did you smoke')
+    .replace('How many large cigars do you currently smoke', 'How many large cigars did you smoke')
+    .replace('How many cigarillos do you currently smoke', 'How many cigarillos did you smoke')
+    .replace('How many hours do you currently smoke', 'How many hours did you smoke')
+    .replace('Do you usually smoke', 'Did you usually smoke')
+    .replace('Has the number of cigarettes you normally smoke changed over time?', 'Did the number of cigarettes you normally smoked change over time?')
+    .replace('Has the amount of rolling tobacco you normally smoke changed over time?', 'Did the amount of rolling tobacco you normally smoked change over time?')
+    .replace('Has the number of full pipe loads you normally smoke changed over time?', 'Did the number of full pipe loads you normally smoked change over time?')
+    .replace('Has the number of small cigars you normally smoke changed over time?', 'Did the number of small cigars you normally smoked change over time?')
+    .replace('Has the number of medium cigars you normally smoke changed over time?', 'Did the number of medium cigars you normally smoked change over time?')
+    .replace('Has the number of large cigars you normally smoke changed over time?', 'Did the number of large cigars you normally smoked change over time?')
+    .replace('Has the number of cigarillos you normally smoke changed over time?', 'Did the number of cigarillos you normally smoked change over time?')
+}
+
+const getSmokingTypeHeadings = (type, isPast = false) => {
+  const smokingType = smokingTypes[type]
+
+  if (!smokingType) {
+    return {}
+  }
+
+  if (!isPast) {
+    return smokingType
+  }
+
+  return {
+    ...smokingType,
+    frequencyHeading: getPastSmokingHeading(smokingType.frequencyHeading),
+    quantityHeading: getPastSmokingHeading(smokingType.quantityHeading),
+    changeHeading: getPastSmokingHeading(smokingType.changeHeading),
+    settingHeading: getPastSmokingHeading(smokingType.settingHeading)
+  }
+}
+
+const getSmokingStepHeading = (page, type, setting, isPast = false) => {
   const smokingType = smokingTypes[type]
   const shishaSetting = shishaSmokingSettings[setting]
 
@@ -551,15 +603,15 @@ const getSmokingStepHeading = (page, type, setting) => {
 
   if (type === 'shisha' && shishaSetting) {
     if (page === 'smoking-frequency') {
-      return `How often do you smoke shisha ${shishaSetting.headingText}?`
+      return `How often ${isPast ? 'did' : 'do'} you smoke shisha ${shishaSetting.headingText}?`
     }
 
     if (page === 'smoking-quantity') {
-      return `How many hours do you currently smoke shisha ${shishaSetting.headingText} in a normal day?`
+      return `How many hours ${isPast ? 'did' : 'do'} you ${isPast ? '' : 'currently '}smoke shisha ${shishaSetting.headingText} in a normal day?`
     }
   }
 
-  return smokingType[`${page.replace('smoking-', '')}Heading`] || ''
+  return getSmokingTypeHeadings(type, isPast)[`${page.replace('smoking-', '')}Heading`] || ''
 }
 
 const getSmokingChangeAnswer = (answer = {}, change) => {
@@ -637,18 +689,19 @@ const getCheckYourAnswers = (answers = {}) => {
 
   const tobaccoRows = selectedSmokingTypes.map((type) => {
     const answer = answers[type] || {}
-    const smokingType = smokingTypes[type]
+    const isPast = isPastSmokingType(answers, answer)
+    const smokingType = getSmokingTypeHeadings(type, isPast)
     const shishaSettingRows = getSelectedShishaSettings(answer).flatMap((setting) => {
       const settingAnswer = getShishaSettingAnswer(answer, setting)
 
       return [
         makeSummaryRow({
-          key: getSmokingStepHeading('smoking-frequency', type, setting),
+          key: getSmokingStepHeading('smoking-frequency', type, setting, isPast),
           value: formatValue(settingAnswer.smokingFrequency, valueLabels.smokingFrequency),
           href: getSmokingTypeStepUrl({ page: 'smoking-frequency', type, setting })
         }),
         makeSummaryRow({
-          key: getSmokingStepHeading('smoking-quantity', type, setting),
+          key: getSmokingStepHeading('smoking-quantity', type, setting, isPast),
           value: getSmokingQuantity(type, settingAnswer.smokingQuantity),
           href: getSmokingTypeStepUrl({ page: 'smoking-quantity', type, setting })
         })
@@ -682,7 +735,7 @@ const getCheckYourAnswers = (answers = {}) => {
         href: getSmokingTypeStepUrl({ page: 'smoking-status', type })
       }),
       type === 'shisha' && makeSummaryRow({
-        key: 'Do you usually smoke shisha in a group or on your own?',
+        key: smokingType.settingHeading,
         ...formatListValue(answer.smokingSetting, valueLabels.smokingSetting),
         href: getSmokingTypeStepUrl({ page: 'smoking-setting', type })
       }),
@@ -698,7 +751,7 @@ const getCheckYourAnswers = (answers = {}) => {
       }),
       type !== 'shisha' && makeSummaryRow({
         key: smokingType.changeHeading,
-        ...formatListValue(answer.smokingChange, getSmokingChangeLabels(type, answer)),
+        ...formatListValue(answer.smokingChange, getSmokingChangeLabels(type, answer, isPast)),
         href: getSmokingTypeStepUrl({ page: 'smoking-change', type })
       }),
       ...shishaSettingRows,
@@ -848,6 +901,20 @@ const getFormerSmokerFallbackStep = (req, page, steps) => {
   return steps.find((step) => step.type === req.query?.type) || steps[0]
 }
 
+const getSmokingTypeQuestionText = (answers = {}) => {
+  if (answers.smoker === 'yes_previous') {
+    return {
+      title: 'The type of tobacco you have smoked',
+      legend: 'What have you smoked?'
+    }
+  }
+
+  return {
+    title: 'The type of tobacco you smoke or used to smoke',
+    legend: 'What do you or have you smoked?'
+  }
+}
+
 const getSmokingTypeActions = (step, steps) => {
   const index = steps.findIndex((item) => item.page === step.page && item.type === step.type && item.change === step.change && item.setting === step.setting)
   const previousStep = steps[index - 1]
@@ -877,6 +944,7 @@ const renderSmokingTypeQuestion = (req, res, page, errors = []) => {
   }
 
   const answer = req.session.data.answers[step.type] || {}
+  const isPast = isPastSmokingType(req.session.data.answers, answer)
   const changeAnswer = getSmokingChangeAnswer(answer, step.change)
   const settingAnswer = getShishaSettingAnswer(answer, step.setting)
 
@@ -884,13 +952,14 @@ const renderSmokingTypeQuestion = (req, res, page, errors = []) => {
     type: step.type,
     change: step.change,
     setting: step.setting,
-    smokingType: smokingTypes[step.type],
+    smokingType: getSmokingTypeHeadings(step.type, isPast),
     smokingChange: smokingChangeTypes[step.change],
-    smokingChangeLabels: getSmokingChangeLabels(step.type, answer),
+    smokingChangeLabels: getSmokingChangeLabels(step.type, answer, isPast),
     smokingSetting: shishaSmokingSettings[step.setting],
     changeAnswer,
     settingAnswer,
-    questionHeading: getSmokingStepHeading(page, step.type, step.setting),
+    isPastSmokingType: isPast,
+    questionHeading: getSmokingStepHeading(page, step.type, step.setting, isPast),
     changeHeading: getSmokingChangeHeading(page, step.type, step.change, changeAnswer, answer),
     errors,
     actions: getSmokingTypeActions(step, steps)
@@ -1667,7 +1736,12 @@ exports.periodsStoppedSmoking_post = (req, res) => {
 /// ------------------------------------------------------------------------ ///
 
 exports.smokingType_get = (req, res) => {
+  const { answers } = req.session.data
+  const smokingTypeQuestionText = getSmokingTypeQuestionText(answers)
+
   res.render(view('questions/smoking-type'), {
+    smokingTypeTitle: smokingTypeQuestionText.title,
+    smokingTypeLegend: smokingTypeQuestionText.legend,
     actions: {
       next: `/prototype_${version}/smoking-type`,
       back: `/prototype_${version}/periods-stopped-smoking`,
@@ -1678,11 +1752,14 @@ exports.smokingType_get = (req, res) => {
 
 exports.smokingType_post = (req, res) => {
   const { answers } = req.session.data
+  const smokingTypeQuestionText = getSmokingTypeQuestionText(answers)
   const errors = []
 
   if (errors.length) {
     res.render(view('questions/smoking-type'), {
       errors,
+      smokingTypeTitle: smokingTypeQuestionText.title,
+      smokingTypeLegend: smokingTypeQuestionText.legend,
       actions: {
         next: `/prototype_${version}/smoking-type`,
         back: `/prototype_${version}/periods-stopped-smoking`,

--- a/app/prototype_v4/controllers/question.js
+++ b/app/prototype_v4/controllers/question.js
@@ -232,11 +232,15 @@ const deleteUnselectedShishaSettingAnswers = (answer = {}) => {
 }
 
 const getSmokingTypeSteps = (answers = {}) => {
+  const includeSmokingStatus = answers.smoker !== 'yes_previous'
+
   return getSelectedSmokingTypes(answers).flatMap((type) => {
     const steps = []
     const answer = answers[type] || {}
 
-    steps.push({ page: 'smoking-status', type })
+    if (includeSmokingStatus) {
+      steps.push({ page: 'smoking-status', type })
+    }
 
     if (type === 'shisha') {
       steps.push({ page: 'smoking-setting', type })
@@ -629,6 +633,7 @@ const formatListValue = (value, labels) => {
 
 const getCheckYourAnswers = (answers = {}) => {
   const selectedSmokingTypes = getSelectedSmokingTypes(answers)
+  const isFormerSmoker = answers.smoker === 'yes_previous'
 
   const tobaccoRows = selectedSmokingTypes.map((type) => {
     const answer = answers[type] || {}
@@ -671,7 +676,7 @@ const getCheckYourAnswers = (answers = {}) => {
       ]
     })
     const rows = makeSummaryRows([
-      makeSummaryRow({
+      !isFormerSmoker && makeSummaryRow({
         key: smokingType.statusHeading,
         value: formatValue(answer.smokingStatus, valueLabels.smokingStatus),
         href: getSmokingTypeStepUrl({ page: 'smoking-status', type })
@@ -797,6 +802,11 @@ const getCheckYourAnswers = (answers = {}) => {
         value: answers.ageStartedSmoking && `Age ${answers.ageStartedSmoking}`,
         href: `/prototype_${version}/age-started-smoking`
       }),
+      isFormerSmoker && makeSummaryRow({
+        key: 'Age you stopped smoking',
+        value: answers.ageStoppedSmoking && `Age ${answers.ageStoppedSmoking}`,
+        href: `/prototype_${version}/age-stopped-smoking`
+      }),
       makeSummaryRow({
         key: 'Stopped smoking for periods of 1 year or longer',
         value: formatValue(answers.periodsStoppedSmoking, valueLabels.periodsStoppedSmoking),
@@ -830,6 +840,14 @@ const getSmokingTypeStep = (req, page) => {
   return { step, steps }
 }
 
+const getFormerSmokerFallbackStep = (req, page, steps) => {
+  if (page !== 'smoking-status' || req.session.data.answers?.smoker !== 'yes_previous') {
+    return false
+  }
+
+  return steps.find((step) => step.type === req.query?.type) || steps[0]
+}
+
 const getSmokingTypeActions = (step, steps) => {
   const index = steps.findIndex((item) => item.page === step.page && item.type === step.type && item.change === step.change && item.setting === step.setting)
   const previousStep = steps[index - 1]
@@ -847,6 +865,13 @@ const renderSmokingTypeQuestion = (req, res, page, errors = []) => {
   const { step, steps } = getSmokingTypeStep(req, page)
 
   if (!step) {
+    const fallbackStep = getFormerSmokerFallbackStep(req, page, steps)
+
+    if (fallbackStep) {
+      res.redirect(getSmokingTypeStepUrl(fallbackStep))
+      return
+    }
+
     res.redirect(`/prototype_${version}/smoking-type`)
     return
   }
@@ -1550,6 +1575,7 @@ exports.ageStartedSmoking_post = (req, res) => {
     if (answers.smoker === 'yes_previous') {
       res.redirect(`/prototype_${version}/age-stopped-smoking`)
     } else {
+      delete answers.ageStoppedSmoking
       res.redirect(`/prototype_${version}/periods-stopped-smoking`)
     }
   }
@@ -1557,6 +1583,11 @@ exports.ageStartedSmoking_post = (req, res) => {
 
 exports.ageStoppedSmoking_get = (req, res) => {
   const { answers } = req.session.data
+
+  if (answers.smoker !== 'yes_previous') {
+    res.redirect(`/prototype_${version}/periods-stopped-smoking`)
+    return
+  }
 
   res.render(view('questions/age-stopped-smoking'), {
     actions: {
@@ -1570,6 +1601,12 @@ exports.ageStoppedSmoking_get = (req, res) => {
 exports.ageStoppedSmoking_post = (req, res) => {
   const { answers } = req.session.data
   const errors = []
+
+  if (answers.smoker !== 'yes_previous') {
+    delete answers.ageStoppedSmoking
+    res.redirect(`/prototype_${version}/periods-stopped-smoking`)
+    return
+  }
 
   // TODO:
   // If not answered, throw error
@@ -1592,7 +1629,7 @@ exports.ageStoppedSmoking_post = (req, res) => {
 
 exports.periodsStoppedSmoking_get = (req, res) => {
   const { answers } = req.session.data
-  const back = answers?.ageStoppedSmoking ? `/prototype_${version}/age-stopped-smoking` : `/prototype_${version}/age-started-smoking`
+  const back = answers.smoker === 'yes_previous' ? `/prototype_${version}/age-stopped-smoking` : `/prototype_${version}/age-started-smoking`
 
   res.render(view('questions/periods-stopped-smoking'), {
     actions: {
@@ -1605,7 +1642,7 @@ exports.periodsStoppedSmoking_get = (req, res) => {
 
 exports.periodsStoppedSmoking_post = (req, res) => {
   const { answers } = req.session.data
-  const back = answers?.ageStoppedSmoking ? `/prototype_${version}/age-stopped-smoking` : `/prototype_${version}/age-started-smoking`
+  const back = answers.smoker === 'yes_previous' ? `/prototype_${version}/age-stopped-smoking` : `/prototype_${version}/age-started-smoking`
   const errors = []
 
   if (errors.length) {
@@ -1613,7 +1650,7 @@ exports.periodsStoppedSmoking_post = (req, res) => {
       errors,
       actions: {
         next: `/prototype_${version}/periods-stopped-smoking`,
-        back: `/prototype_${version}/age-started-smoking`,
+        back,
         cancel: `/prototype_${version}/`
       }
     })
@@ -1657,6 +1694,11 @@ exports.smokingType_post = (req, res) => {
       ? answers.smokingType
       : [answers.smokingType].filter(Boolean)
     deleteUnselectedSmokingTypeAnswers(answers)
+    if (answers.smoker === 'yes_previous') {
+      getSelectedSmokingTypes(answers).forEach((type) => {
+        delete answers[type]?.smokingStatus
+      })
+    }
     const steps = getSmokingTypeSteps(answers)
 
     if (selectedTypes.includes('none')) {
@@ -1686,6 +1728,13 @@ exports.smokingStatus_post = (req, res) => {
   const errors = []
 
   if (!step) {
+    const fallbackStep = getFormerSmokerFallbackStep(req, 'smoking-status', steps)
+
+    if (fallbackStep) {
+      res.redirect(getSmokingTypeStepUrl(fallbackStep))
+      return
+    }
+
     res.redirect(`/prototype_${version}/smoking-type`)
     return
   }

--- a/app/prototype_v4/controllers/question.js
+++ b/app/prototype_v4/controllers/question.js
@@ -1547,15 +1547,57 @@ exports.ageStartedSmoking_post = (req, res) => {
       }
     })
   } else {
+    if (answers.smoker === 'yes_previous') {
+      res.redirect(`/prototype_${version}/age-stopped-smoking`)
+    } else {
+      res.redirect(`/prototype_${version}/periods-stopped-smoking`)
+    }
+  }
+}
+
+exports.ageStoppedSmoking_get = (req, res) => {
+  const { answers } = req.session.data
+
+  res.render(view('questions/age-stopped-smoking'), {
+    actions: {
+      next: `/prototype_${version}/age-stopped-smoking`,
+      back: `/prototype_${version}/age-started-smoking`,
+      cancel: `/prototype_${version}/`
+    }
+  })
+}
+
+exports.ageStoppedSmoking_post = (req, res) => {
+  const { answers } = req.session.data
+  const errors = []
+
+  // TODO:
+  // If not answered, throw error
+  // If the age stopped smoking is older than person's age
+  // based on date of birth, throw error
+
+  if (errors.length) {
+    res.render(view('questions/age-stopped-smoking'), {
+      errors,
+      actions: {
+        next: `/prototype_${version}/age-stopped-smoking`,
+        back: `/prototype_${version}/age-started-smoking`,
+        cancel: `/prototype_${version}/`
+      }
+    })
+  } else {
     res.redirect(`/prototype_${version}/periods-stopped-smoking`)
   }
 }
 
 exports.periodsStoppedSmoking_get = (req, res) => {
+  const { answers } = req.session.data
+  const back = answers?.ageStoppedSmoking ? `/prototype_${version}/age-stopped-smoking` : `/prototype_${version}/age-started-smoking`
+
   res.render(view('questions/periods-stopped-smoking'), {
     actions: {
       next: `/prototype_${version}/periods-stopped-smoking`,
-      back: `/prototype_${version}/age-started-smoking`,
+      back,
       cancel: `/prototype_${version}/`
     }
   })
@@ -1563,6 +1605,7 @@ exports.periodsStoppedSmoking_get = (req, res) => {
 
 exports.periodsStoppedSmoking_post = (req, res) => {
   const { answers } = req.session.data
+  const back = answers?.ageStoppedSmoking ? `/prototype_${version}/age-stopped-smoking` : `/prototype_${version}/age-started-smoking`
   const errors = []
 
   if (errors.length) {

--- a/app/prototype_v4/routes.js
+++ b/app/prototype_v4/routes.js
@@ -146,6 +146,9 @@ router.post(`/prototype_${version}/cancer-diagnosis-relatives-age`, questionCont
 router.get(`/prototype_${version}/age-started-smoking`, questionController.ageStartedSmoking_get)
 router.post(`/prototype_${version}/age-started-smoking`, questionController.ageStartedSmoking_post)
 
+router.get(`/prototype_${version}/age-stopped-smoking`, questionController.ageStoppedSmoking_get)
+router.post(`/prototype_${version}/age-stopped-smoking`, questionController.ageStoppedSmoking_post)
+
 router.get(`/prototype_${version}/periods-stopped-smoking`, questionController.periodsStoppedSmoking_get)
 router.post(`/prototype_${version}/periods-stopped-smoking`, questionController.periodsStoppedSmoking_post)
 

--- a/app/prototype_v4/views/questions/age-stopped-smoking.html
+++ b/app/prototype_v4/views/questions/age-stopped-smoking.html
@@ -1,0 +1,53 @@
+{% extends "prototype_v4/views/layouts/main.html" %}
+
+{% set title = "How old were you when you stopped smoking?" %}
+
+{% block beforeContent %}
+{{ backLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+  {% include "prototype_v4/views/includes/error-summary.html" %}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% set headingHtml %}
+        {% include "prototype_v4/views/includes/page-heading-legend.html" %}
+      {% endset %}
+
+      <form action="{{ actions.next }}" method="post" accept-charset="utf-8" novalidate>
+
+        {{ input({
+          id: "age-stopped-smoking",
+          name: "answers[ageStoppedSmoking]",
+          label: {
+            html: headingHtml,
+            isPageHeading: true,
+            classes: "nhsuk-label--l"
+          },
+          hint: {
+            text: "Give an estimate if you are not sure"
+          },
+          prefix: "Age",
+          inputmode: "numeric",
+          value: data.answers.ageStoppedSmoking,
+          classes: "nhsuk-input--width-2"
+        }) }}
+
+        {{ button({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+      <p class="nhsuk-body">
+        <a class="nhsuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/prototype_v4/views/questions/smoking-change.html
+++ b/app/prototype_v4/views/questions/smoking-change.html
@@ -51,7 +51,7 @@
             },
             {
               value: "no",
-              text: "No, it has not changed",
+              text: smokingChangeLabels.no,
               exclusive: true,
               exclusiveGroup: "change-list"
             }

--- a/app/prototype_v4/views/questions/smoking-frequency-change.html
+++ b/app/prototype_v4/views/questions/smoking-frequency-change.html
@@ -48,7 +48,7 @@
               value: "monthly",
               text: "Monthly",
               hint: {
-                text: "Select this option if you smoke at least once a month"
+                text: "Select this option if you smoked at least once a month"
               }
             },
             {

--- a/app/prototype_v4/views/questions/smoking-frequency.html
+++ b/app/prototype_v4/views/questions/smoking-frequency.html
@@ -55,7 +55,7 @@
               value: "monthly",
               text: "Monthly",
               hint: {
-                text: "Select this option if you smoke at least once a month"
+                text: "Select this option if you " + ("smoked" if isPastSmokingType else "smoke") + " at least once a month"
               }
             },
             {

--- a/app/prototype_v4/views/questions/smoking-type.html
+++ b/app/prototype_v4/views/questions/smoking-type.html
@@ -1,6 +1,6 @@
 {% extends "prototype_v4/views/layouts/main.html" %}
 
-{% set title = "The type of tobacco you smoke or used to smoke" %}
+{% set title = smokingTypeTitle or "The type of tobacco you smoke or used to smoke" %}
 
 {% set bodyTextMarkdown %}
 Smoking affects your health in different ways depending on what you smoke.
@@ -33,7 +33,7 @@ You do not need to tell us about less frequent forms of smoking. For example, a 
           name: "answers[smokingType]",
           fieldset: {
             legend: {
-              text: "What do you or have you smoked?",
+              text: smokingTypeLegend or "What do you or have you smoked?",
               isPageHeading: false,
               classes: "nhsuk-fieldset__legend--m"
             }


### PR DESCRIPTION
This PR updates the prototype to reflect past vs present smoking habits.

We have two ways of capturing if someone used to smoke:

1. "Have you ever smoked tobacco?"
2. "Do you currently smoke [tobacco_type]?"

If the user has previously smoked, or answers "no" to the smoking status question, we show question labels in the past tense. For example:

1. "How often do you smoke cigarettes?" becomes "How often did you smoke cigarettes?"
2. "How many cigarettes do you currently smoke in a normal day?" becomes "How many cigarettes did you smoke in a normal day?"
3. "Has the number of cigarettes you normally smoke changed over time?" becomes "Did the number of cigarettes you normally smoked change over time?" - the checkbox options also need to change
4. If the user is a previous smoke, then the smoking type becomes: "What have you smoked?"

If the user says they are a previous smoker, we now include a 'age stopped smoking' question after the age started smoking question.

View deployment: https://lung-health-check-pr-68.herokuapp.com/