### PR TITLE
Update how we show frequency options

### DIFF
--- a/app/prototype_v4_4/docs/question-flow.md
+++ b/app/prototype_v4_4/docs/question-flow.md
@@ -86,20 +86,37 @@ flowchart TD
   isShisha -- No --> changed{"Smoking changed<br>over time?"}
 
   changed -- No change selected --> nextTypeOrCya
-  changed -- More selected --> moreFrequency["More: smoking frequency"]
-  moreFrequency --> moreQuantity["More: smoking quantity"]
+  changed -- More selected --> moreFrequencyNeeded{"More: more than one<br>frequency option?"}
+  moreFrequencyNeeded -- Yes --> moreFrequency["More: smoking frequency"]
+  moreFrequencyNeeded -- No, default frequency --> moreQuantity["More: smoking quantity"]
+  moreFrequency --> moreQuantity
   moreQuantity --> moreYears["More: smoking years"]
   moreYears --> fewerSelected{"Fewer also selected?"}
 
-  changed -- Only fewer selected --> fewerFrequency["Fewer: smoking frequency"]
-  fewerSelected -- Yes --> fewerFrequency
+  changed -- Only fewer selected --> fewerFrequencyNeeded{"Fewer: more than one<br>frequency option?"}
+  fewerSelected -- Yes --> fewerFrequencyNeeded
   fewerSelected -- No --> nextTypeOrCya
+  fewerFrequencyNeeded -- Yes --> fewerFrequency["Fewer: smoking frequency"]
+  fewerFrequencyNeeded -- No, default frequency --> fewerQuantity["Fewer: smoking quantity"]
   fewerFrequency --> fewerQuantity["Fewer: smoking quantity"]
   fewerQuantity --> fewerYears["Fewer: smoking years"]
   fewerYears --> nextTypeOrCya
 
   nextTypeOrCya["Tobacco type summary<br>then next selected type<br>or Respiratory conditions"]
 ```
+
+## Changed-smoking frequency options
+
+Changed-smoking frequency uses the current or usual smoking frequency as a boundary. The question is only shown when there is more than one valid option.
+
+| Current or usual frequency | If smoked more | If smoked fewer or less |
+| --- | --- | --- |
+| Daily | Default to daily and skip frequency question | Daily, weekly, monthly, yearly |
+| Weekly | Daily, weekly | Weekly, monthly, yearly |
+| Monthly | Daily, weekly, monthly | Monthly, yearly |
+| Yearly | Daily, weekly, monthly, yearly | Default to yearly and skip frequency question |
+
+When the changed-smoking frequency is defaulted, the answer is still stored and shown in summaries, but the frequency row does not include a `Change` link.
 
 ## Notes
 
@@ -109,7 +126,8 @@ flowchart TD
 - `Age stopped smoking` is shown on `When you smoked tobacco` when the `smoker` answer is `yes_previous`. It can also be shown again from check your answers if a tobacco-specific `Smoking status` answer is `no`.
 - `Years smoked` is shown for each selected tobacco type only when more than one tobacco type has been selected.
 - Smoking frequency and smoking quantity are separate pages.
-- Changed-smoking frequency, quantity and years are separate pages.
+- Changed-smoking quantity and years are separate pages. Changed-smoking frequency is a separate page only when more than one frequency option applies.
+- Changed-smoking quantity uses the selected or defaulted changed-smoking frequency to set its `normal day`, `normal week`, `normal month` or `normal year` wording.
 - The tobacco subflow uses query strings such as `/prototype_v4_4/smoking-status?type=cigarettes`, `/prototype_v4_4/years-smoked?type=cigarettes` and `/prototype_v4_4/smoking-frequency-change?type=cigarettes&change=greater`.
 - If the `smoker` answer is `yes_previous`, each tobacco type skips `Smoking status` and uses past-tense question text.
 - Shisha follows the same smoking frequency and quantity flow as other tobacco types, but skips the smoking-change flow.

--- a/app/prototype_v4_4/lib/question-renderer.js
+++ b/app/prototype_v4_4/lib/question-renderer.js
@@ -162,6 +162,8 @@ const mergeQuestionOverrides = (question, overrides = {}) => {
  * @param {string} id - Page id from pages.yaml.
  * @param {Object} actions - URLs used by the grouped question template.
  * @param {Object[]} [errors] - Validation errors for all questions on the page.
+ * @param {Object} [answers] - Session answers object used for conditional questions.
+ * @param {Object} [overrides] - Runtime overrides for page or question content.
  */
 const renderQuestionPage = (res, id, actions, errors = [], answers = {}, overrides = {}) => {
   const page = getQuestionPage(id, answers)

--- a/app/prototype_v4_4/lib/summary.js
+++ b/app/prototype_v4_4/lib/summary.js
@@ -6,6 +6,7 @@ const {
   getSelectedSmokingChanges,
   getSelectedSmokingTypes,
   getSmokingChangeAnswer,
+  getSmokingChangeFrequencyOptions,
   getSmokingChangeHeading,
   getSmokingChangeLabels,
   getSmokingCurrentAmount,
@@ -13,6 +14,7 @@ const {
   getSmokingStepHeading,
   getSmokingTypeHeadings,
   getSmokingTypeStepUrl,
+  isSmokingChangeFrequencyDefaulted,
   isPastSmokingType,
   getValueLabels: getTobaccoValueLabels
 } = require('./tobacco-flow')
@@ -140,7 +142,7 @@ const formatValue = (value, labels) => {
  * @param {string} row.key - Question text.
  * @param {string} [row.value] - Plain text answer value.
  * @param {string} [row.html] - HTML answer value.
- * @param {string} row.href - Change link URL.
+ * @param {string} [row.href] - Change link URL.
  * @param {string} [row.visuallyHiddenText] - Custom visually hidden action text.
  * @returns {SummaryRow|boolean} Summary row, or false when there is no value.
  */
@@ -156,15 +158,17 @@ const makeSummaryRow = ({ key, value, html, href, visuallyHiddenText }) => {
     value: html
       ? { html }
       : { text: value },
-    actions: {
-      items: [
-        {
-          href,
-          text: 'Change',
-          visuallyHiddenText: visuallyHiddenText || key
+    actions: href
+      ? {
+          items: [
+            {
+              href,
+              text: 'Change',
+              visuallyHiddenText: visuallyHiddenText || key
+            }
+          ]
         }
-      ]
-    }
+      : undefined
   }
 }
 
@@ -234,14 +238,26 @@ const getSmokingChangeSummaryHeading = (type, change, answer = {}) => {
 
 const valueLabelFallback = (value, labels = {}) => labels[value] || value
 
+const getSmokingChangeFrequencyValue = (answer = {}, change, changeAnswer = {}) => {
+  const options = getSmokingChangeFrequencyOptions(answer, change)
+
+  return options.length === 1 ? options[0] : changeAnswer.frequency
+}
+
+const getSmokingChangeFrequencyHref = (type, change, answer = {}) => {
+  return isSmokingChangeFrequencyDefaulted(answer, change)
+    ? undefined
+    : getSmokingTypeStepUrl({ page: 'smoking-frequency-change', type, change })
+}
+
 const getTobaccoChangeSummaryRows = (type, change, answer = {}, valueLabels = {}) => {
   const changeAnswer = getSmokingChangeAnswer(answer, change)
 
   return makeSummaryRows([
     makeSummaryRow({
       key: 'How often did you smoke?',
-      value: formatValue(changeAnswer.frequency, valueLabels.smokingFrequency),
-      href: getSmokingTypeStepUrl({ page: 'smoking-frequency-change', type, change })
+      value: formatValue(getSmokingChangeFrequencyValue(answer, change, changeAnswer), valueLabels.smokingFrequency),
+      href: getSmokingChangeFrequencyHref(type, change, answer)
     }),
     makeSummaryRow({
       key: 'How much did you smoke?',
@@ -287,8 +303,8 @@ const getCheckYourAnswers = (answers = {}) => {
       return [
         makeSummaryRow({
           key: getSmokingChangeHeading('smoking-frequency-change', type, change, changeAnswer, answer),
-          value: formatValue(changeAnswer.frequency, valueLabels.smokingFrequency),
-          href: getSmokingTypeStepUrl({ page: 'smoking-frequency-change', type, change })
+          value: formatValue(getSmokingChangeFrequencyValue(answer, change, changeAnswer), valueLabels.smokingFrequency),
+          href: getSmokingChangeFrequencyHref(type, change, answer)
         }),
         makeSummaryRow({
           key: getSmokingChangeHeading('smoking-quantity-change', type, change, changeAnswer, answer),

--- a/app/prototype_v4_4/lib/summary.js
+++ b/app/prototype_v4_4/lib/summary.js
@@ -132,7 +132,7 @@ const formatValue = (value, labels) => {
  * @typedef {Object} SummaryRow
  * @property {Object} key - NHS summary-list key config.
  * @property {Object} [value] - NHS summary-list value config.
- * @property {Object} actions - NHS summary-list actions config.
+ * @property {Object} [actions] - NHS summary-list actions config.
  */
 
 /**
@@ -238,18 +238,43 @@ const getSmokingChangeSummaryHeading = (type, change, answer = {}) => {
 
 const valueLabelFallback = (value, labels = {}) => labels[value] || value
 
+/**
+ * Resolve the frequency value to show for a changed-smoking answer.
+ *
+ * @param {Object} answer - Answer object for one tobacco type.
+ * @param {string} change - Smoking change key.
+ * @param {Object} changeAnswer - Change-specific answer object.
+ * @returns {string|undefined} Frequency value for display.
+ */
 const getSmokingChangeFrequencyValue = (answer = {}, change, changeAnswer = {}) => {
   const options = getSmokingChangeFrequencyOptions(answer, change)
 
   return options.length === 1 ? options[0] : changeAnswer.frequency
 }
 
+/**
+ * Get the change-frequency summary row URL when the frequency page applies.
+ *
+ * @param {string} type - Tobacco type key.
+ * @param {string} change - Smoking change key.
+ * @param {Object} answer - Answer object for one tobacco type.
+ * @returns {string|undefined} Change URL, or undefined for defaulted frequencies.
+ */
 const getSmokingChangeFrequencyHref = (type, change, answer = {}) => {
   return isSmokingChangeFrequencyDefaulted(answer, change)
     ? undefined
     : getSmokingTypeStepUrl({ page: 'smoking-frequency-change', type, change })
 }
 
+/**
+ * Build changed-smoking summary rows for a tobacco type and change direction.
+ *
+ * @param {string} type - Tobacco type key.
+ * @param {string} change - Smoking change key.
+ * @param {Object} answer - Answer object for one tobacco type.
+ * @param {Object} valueLabels - Display labels keyed by submitted value.
+ * @returns {SummaryRow[]} Changed-smoking summary rows.
+ */
 const getTobaccoChangeSummaryRows = (type, change, answer = {}, valueLabels = {}) => {
   const changeAnswer = getSmokingChangeAnswer(answer, change)
 

--- a/app/prototype_v4_4/lib/tobacco-flow.js
+++ b/app/prototype_v4_4/lib/tobacco-flow.js
@@ -181,6 +181,8 @@ const getSmokingTypeSteps = (answers = {}) => {
     const steps = []
     const answer = answers[type] || {}
 
+    normaliseSmokingChangeFrequencyAnswers(answer)
+
     if (includeSmokingStatus) {
       steps.push({ page: 'smoking-status', type })
     }
@@ -195,7 +197,10 @@ const getSmokingTypeSteps = (answers = {}) => {
     if (type !== 'shisha') {
       steps.push({ page: 'smoking-change', type })
       getSelectedSmokingChanges(answer).forEach((change) => {
-        steps.push({ page: 'smoking-frequency-change', type, change })
+        if (!isSmokingChangeFrequencyDefaulted(answer, change)) {
+          steps.push({ page: 'smoking-frequency-change', type, change })
+        }
+
         steps.push({ page: 'smoking-quantity-change', type, change })
         steps.push({ page: 'smoking-years-change', type, change })
       })
@@ -315,6 +320,94 @@ const smokingFrequencyRateMultipliers = {
   weekly: 1,
   monthly: 0.25,
   yearly: 1 / 52
+}
+
+const smokingFrequencyOrder = [
+  'daily',
+  'weekly',
+  'monthly',
+  'yearly'
+]
+
+/**
+ * Get the frequency options that can apply to a changed-smoking answer.
+ *
+ * This is intentionally ordinal rather than mathematical. For example, if
+ * someone smoked fewer than a weekly baseline, daily is not offered.
+ *
+ * @param {Object} answer - Answer object for one tobacco type.
+ * @param {string} change - Smoking change key.
+ * @returns {string[]} Frequency values that should be offered.
+ */
+const getSmokingChangeFrequencyOptions = (answer = {}, change) => {
+  const currentIndex = smokingFrequencyOrder.indexOf(answer.smokingFrequency)
+
+  if (currentIndex === -1) {
+    return smokingFrequencyOrder
+  }
+
+  if (change === 'greater') {
+    return smokingFrequencyOrder.slice(0, currentIndex + 1)
+  }
+
+  if (change === 'fewer') {
+    return smokingFrequencyOrder.slice(currentIndex)
+  }
+
+  return smokingFrequencyOrder
+}
+
+/**
+ * Check whether the change-frequency question has a single default answer.
+ *
+ * @param {Object} answer - Answer object for one tobacco type.
+ * @param {string} change - Smoking change key.
+ * @returns {boolean} True when frequency should be defaulted and not changed.
+ */
+const isSmokingChangeFrequencyDefaulted = (answer = {}, change) => {
+  return getSmokingChangeFrequencyOptions(answer, change).length === 1
+}
+
+/**
+ * Get or create the nested changed-smoking answer object.
+ *
+ * @param {Object} answer - Answer object for one tobacco type.
+ * @param {string} change - Smoking change key.
+ * @returns {Object} Writable nested answer object.
+ */
+const getWritableSmokingChangeAnswer = (answer = {}, change) => {
+  refreshData()
+
+  const answerKey = smokingChangeTypes[change]?.answerKey
+
+  if (!answerKey) {
+    return {}
+  }
+
+  answer[answerKey] = answer[answerKey] || {}
+
+  return answer[answerKey]
+}
+
+/**
+ * Default single-option changed frequencies and remove stale invalid ones.
+ *
+ * @param {Object} answer - Answer object for one tobacco type, mutated in place.
+ */
+const normaliseSmokingChangeFrequencyAnswers = (answer = {}) => {
+  getSelectedSmokingChanges(answer).forEach((change) => {
+    const options = getSmokingChangeFrequencyOptions(answer, change)
+    const changeAnswer = getWritableSmokingChangeAnswer(answer, change)
+
+    if (options.length === 1) {
+      changeAnswer.frequency = options[0]
+      return
+    }
+
+    if (changeAnswer.frequency && !options.includes(changeAnswer.frequency)) {
+      delete changeAnswer.frequency
+    }
+  })
 }
 
 /**
@@ -740,7 +833,7 @@ const getSmokingChangeHeading = (page, type, change, changeAnswer = {}, answer =
   }
 
   if (page === 'smoking-quantity-change') {
-    const baseHeading = applySmokingFrequencyPeriod(getSmokingTypeHeadings(type, true).quantityHeading, answer.smokingFrequency)
+    const baseHeading = applySmokingFrequencyPeriod(getSmokingTypeHeadings(type, true).quantityHeading, changeAnswer.frequency || answer.smokingFrequency)
     const normalHeading = baseHeading
       .replace(' did you smoke ', ' did you normally smoke ')
       .replace(' did you smoke?', ' did you normally smoke?')
@@ -1183,6 +1276,8 @@ const getSmokingContentQuestionOverrides = ({
   }
 
   if (page === 'smoking-frequency-change') {
+    const availableFrequencies = getSmokingChangeFrequencyOptions(answer, step.change)
+
     return {
       heading: {
         title: getSmokingChangeHeading(page, step.type, step.change, changeAnswer, answer),
@@ -1192,7 +1287,9 @@ const getSmokingContentQuestionOverrides = ({
         name: `answers[${step.type}][${smokingChange.answerKey}][frequency]`
       },
       value: changeAnswer.frequency,
-      items: getQuestion('smoking-frequency-change').items
+      items: getQuestion('smoking-frequency-change').items.filter((item) => {
+        return !item.value || availableFrequencies.includes(item.value)
+      })
     }
   }
 
@@ -1205,7 +1302,7 @@ const getSmokingContentQuestionOverrides = ({
       name: `answers[${step.type}][${smokingChange.answerKey}][quantity]`,
       value: changeAnswer.quantity,
       conditionalValue: changeAnswer.smokingQuantityOther,
-      frequency: answer.smokingFrequency,
+      frequency: changeAnswer.frequency || answer.smokingFrequency,
       smokingType
     })
   }
@@ -1344,6 +1441,19 @@ const validateSmokingTypeQuestion = (req, page, step) => {
     ...overrides,
     errors
   })
+
+  if (
+    page === 'smoking-frequency-change' &&
+    context.changeAnswer.frequency &&
+    !getSmokingChangeFrequencyOptions(context.answer, step.change).includes(context.changeAnswer.frequency) &&
+    !validationErrors.some((error) => error.href === `#${errorHref}`)
+  ) {
+    validationErrors.push({
+      text: errors.required.text,
+      href: `#${errorHref}`
+    })
+  }
+
   const comparisonError = getSmokingQuantityChangeComparisonError({
     page,
     step,
@@ -1370,6 +1480,7 @@ module.exports = {
   getSelectedSmokingTypes,
   getFormerSmokerFallbackStep,
   getSmokingChangeAnswer,
+  getSmokingChangeFrequencyOptions,
   getSmokingChangeHeading,
   getSmokingChangeLabels,
   getSmokingCurrentAmount,
@@ -1383,6 +1494,7 @@ module.exports = {
   getSmokingTypeStep,
   getSmokingTypeSteps,
   getSmokingTypeStepUrl,
+  isSmokingChangeFrequencyDefaulted,
   isPastSmokingType,
   renderSmokingTypeQuestion,
   validateSmokingTypeQuestion,

--- a/app/prototype_v4_4/lib/tobacco-flow.js
+++ b/app/prototype_v4_4/lib/tobacco-flow.js
@@ -599,6 +599,24 @@ const getSmokingCurrentAmount = (type, answer = {}) => {
 }
 
 /**
+ * Build the changed amount phrase used in changed-smoking years headings.
+ *
+ * @param {string} type - Tobacco type key.
+ * @param {Object} changeAnswer - Change-specific answer object.
+ * @returns {string} Amount phrase, for example `15 cigarettes a month`.
+ */
+const getSmokingChangedAmount = (type, changeAnswer = {}) => {
+  const quantity = getSmokingQuantity(type, changeAnswer.quantity)
+  const period = getSmokingFrequencyPeriod(changeAnswer.frequency)
+
+  if (!quantity) {
+    return ''
+  }
+
+  return [lowerFirst(quantity), period].filter(Boolean).join(' ')
+}
+
+/**
  * Decide whether a tobacco type should use past-tense content.
  *
  * @param {Object} answers - Session answers object.
@@ -827,23 +845,31 @@ const getSmokingChangeHeading = (page, type, change, changeAnswer = {}, answer =
   const comparisonText = getSmokingChangeComparisonText(type, change, answer)
 
   if (page === 'smoking-frequency-change') {
-    const baseHeading = applySmokingFrequencyPeriod(getSmokingTypeHeadings(type, true).frequencyHeading, answer.smokingFrequency)
+    const baseHeading = getQuestion('smoking-frequency-change').input.label
 
-    return includeComparison && comparisonText ? `${baseHeading.replace('?', '')} ${comparisonText}?` : baseHeading
+    return includeComparison && comparisonText ? `${upperFirst(comparisonText)}, ${lowerFirst(baseHeading)}` : baseHeading
   }
 
   if (page === 'smoking-quantity-change') {
     const baseHeading = applySmokingFrequencyPeriod(getSmokingTypeHeadings(type, true).quantityHeading, changeAnswer.frequency || answer.smokingFrequency)
+    const contextualHeading = baseHeading
+      .replace(' did you smoke ', ' did you normally smoke ')
+      .replace(' did you smoke?', ' did you normally smoke?')
+      .replace(/ in a normal (day|week|month|year)\?$/, ' a $1?')
     const normalHeading = baseHeading
       .replace(' did you smoke ', ' did you normally smoke ')
       .replace(' did you smoke?', ' did you normally smoke?')
       .replace(/ in a normal (day|week|month|year)\?$/, '?')
 
-    return includeComparison && comparisonText ? `${baseHeading.replace('?', '')} ${comparisonText}?` : normalHeading
+    return includeComparison && comparisonText ? `${upperFirst(comparisonText)}, ${lowerFirst(contextualHeading)}` : normalHeading
   }
 
   if (page === 'smoking-years-change') {
-    return getQuestion('smoking-years-change').input.label
+    const amount = getSmokingChangedAmount(type, changeAnswer)
+
+    return amount
+      ? `Roughly how many years did you smoke ${amount}?`
+      : 'Roughly how many years did you smoke this amount?'
   }
 
   return ''
@@ -1072,6 +1098,7 @@ const upperFirst = (value = '') => {
  */
 const getAnswerPhraseFromHeading = (heading = '') => {
   return lowerFirst(removeQuestionMark(heading))
+    .replace(/^roughly how many years did you smoke(?= |$)/, 'roughly how many years you smoked')
     .replace(/^how often did you smoke /, 'how often you smoked ')
     .replace(/^how often do you smoke /, 'how often you smoke ')
     .replace(/^how long did you smoke /, 'how long you smoked ')
@@ -1126,7 +1153,7 @@ const getContextualRequiredErrorText = (question, overrides) => {
     return `Select ${getAnswerPhraseFromHeading(heading)}`
   }
 
-  if (heading.startsWith('How much') || heading.startsWith('How many') || heading.startsWith('How long')) {
+  if (heading.startsWith('How much') || heading.startsWith('How many') || heading.startsWith('How long') || heading.startsWith('Roughly how many')) {
     return `${questionType === 'single' ? 'Select' : 'Enter'} ${getAnswerPhraseFromHeading(heading)}`
   }
 
@@ -1143,7 +1170,7 @@ const getContextualRequiredErrorText = (question, overrides) => {
 const getContextualInvalidErrorText = (question, overrides) => {
   const heading = overrides.heading?.title || question.heading?.title || ''
 
-  if (heading.startsWith('How much') || heading.startsWith('How many') || heading.startsWith('How long')) {
+  if (heading.startsWith('How much') || heading.startsWith('How many') || heading.startsWith('How long') || heading.startsWith('Roughly how many')) {
     return `Enter ${getAnswerPhraseFromHeading(heading)} using numbers`
   }
 


### PR DESCRIPTION
This PR updates how we show frequency options in the change amount flow.

Changed-smoking frequency uses the current or usual smoking frequency as a boundary. The question is only shown when there is more than one valid option.

| Current frequency | If smoked more | If smoked fewer or less |
| --- | --- | --- |
| Daily | Default to daily and skip frequency question | Daily, weekly, monthly, yearly |
| Weekly | Daily, weekly | Weekly, monthly, yearly |
| Monthly | Daily, weekly, monthly | Monthly, yearly |
| Yearly | Daily, weekly, monthly, yearly | Default to yearly and skip frequency question |

When the changed-smoking frequency is defaulted, the answer is still stored and shown in summaries, but the frequency row does not include a `Change` link.

View deployment: https://lung-health-check-pr-105.herokuapp.com/prototype_v4_4/start-page